### PR TITLE
Druid 33.0.0 vectorized lookup extension

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -18,7 +18,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <packaging>pom</packaging>
@@ -222,6 +223,8 @@
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-lookups-cached-single</argument>
                                         <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions:druid-vectorized-lookups</argument>
+                                        <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-multi-stage-query</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-protobuf-extensions</argument>
@@ -303,8 +306,8 @@
             <build>
                 <plugins>
                     <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>exec-maven-plugin</artifactId>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>generate-licenses-report</id>
@@ -522,6 +525,10 @@
                                         <argument>org.apache.druid.extensions:druid-kinesis-indexing-service</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-lookups-cached-global</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions:druid-lookups-cached-single</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions:druid-vectorized-lookups</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-multi-stage-query</argument>
                                         <argument>-c</argument>

--- a/extensions-core/vectorized-lookups/README.md
+++ b/extensions-core/vectorized-lookups/README.md
@@ -1,0 +1,50 @@
+# Vectorized Lookups Extension
+
+This extension provides a vectorized implementation of Druid lookups for improved performance.
+
+## Features
+
+### VECTORIZED_LOOKUP SQL Function
+
+The `VECTORIZED_LOOKUP` function provides the same functionality as the standard `LOOKUP` function but uses a vectorized implementation for better performance.
+
+#### Syntax
+
+```sql
+VECTORIZED_LOOKUP(expr, lookupName[, replaceMissingValueWith])
+```
+
+#### Parameters
+
+- `expr`: The expression to look up in the lookup table
+- `lookupName`: The name of the registered lookup table
+- `replaceMissingValueWith`: (Optional) The value to return if the lookup key is not found
+
+#### Examples
+
+```sql
+-- Basic lookup
+SELECT VECTORIZED_LOOKUP(dim1, 'my_lookup') AS lookup_result
+FROM druid.foo
+
+-- Lookup with default value
+SELECT VECTORIZED_LOOKUP(dim1, 'my_lookup', 'NOT_FOUND') AS lookup_result
+FROM druid.foo
+
+-- Lookup in WHERE clause
+SELECT COUNT(*)
+FROM druid.foo
+WHERE VECTORIZED_LOOKUP(dim1, 'my_lookup') = 'expected_value'
+```
+
+## Installation
+
+This extension is included in the core Druid distribution. No additional installation is required.
+
+## Configuration
+
+The extension is automatically loaded when the vectorized-lookups extension is enabled. The `VECTORIZED_LOOKUP` function will be available alongside the standard `LOOKUP` function.
+
+## Performance
+
+The vectorized implementation provides improved performance for lookup operations by processing multiple values in batches rather than individually. This is particularly beneficial for queries that perform lookups on large datasets.

--- a/extensions-core/vectorized-lookups/pom.xml
+++ b/extensions-core/vectorized-lookups/pom.xml
@@ -47,6 +47,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-sql</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mapdb</groupId>
       <artifactId>mapdb</artifactId>
     </dependency>
@@ -108,6 +114,13 @@
     <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-sql</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/extensions-core/vectorized-lookups/pom.xml
+++ b/extensions-core/vectorized-lookups/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.druid.extensions</groupId>
+  <artifactId>druid-vectorized-lookups</artifactId>
+  <name>druid-vectorized-lookups</name>
+  <description>Extension to rename Druid dimension values using lookups </description>
+
+  <parent>
+    <groupId>org.apache.druid</groupId>
+    <artifactId>druid</artifactId>
+    <version>33.0.0</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mapdb</groupId>
+      <artifactId>mapdb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>stringtemplate</artifactId>
+      <version>3.2</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jdbi</groupId>
+      <artifactId>jdbi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Tests -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>${mysql.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${postgresql.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/DataFetcher.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/DataFetcher.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.druid.server.vectorizedlookup.jdbc.JdbcDataFetcher;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class will be used to pull data from a given lookup table.
+ *
+ * @param <K> Keys type
+ * @param <V> Values type
+ */
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "jdbcDataFetcher", value = JdbcDataFetcher.class)
+})
+public interface DataFetcher<K, V>
+{
+  /**
+   * Function used to fetch all the pair of key-values from the lookup
+   * One use case of this method is to populate a polling cache {@link org.apache.druid.server.vectorizedlookup.cache.polling.PollingCache}
+   *
+   * @return Returns an {@link Iterable} of key-value pairs.
+   */
+  Iterable<Map.Entry<K, V>> fetchAll();
+
+  /**
+   * Function to perform a one item lookup.
+   * For instance this can be used by a loading cache to fetch the value in case of the cache doesn't have it
+   *
+   * @param key non-null key used to lookup the value
+   *
+   * @return Returns null if the key doesn't have an associated value, or the value if it exists
+   */
+  @Nullable V fetch(K key);
+
+  /**
+   * Function used to perform a bulk lookup
+   *
+   * @param keys used to lookup the respective values
+   *
+   * @return Returns a {@link Iterable} containing the pair of existing key-value.
+   */
+  Iterable<Map.Entry<K, V>> fetch(Iterable<K> keys);
+
+  /**
+   * Function used to perform reverse lookup
+   *
+   * @param value use to fetch it's keys from the lookup table
+   *
+   * @return Returns a list of keys of the given {@code value} or an empty list {@link java.util.Collections.EmptyList}
+   */
+  List<K> reverseFetchKeys(V value);
+
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LoadingLookup.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LoadingLookup.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+
+import com.google.common.base.Preconditions;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.query.lookup.LookupExtractor;
+import org.apache.druid.server.vectorizedlookup.cache.loading.LoadingCache;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Loading  lookup will load the key\value pair upon request on the key it self, the general algorithm is load key if absent.
+ * Once the key/value  pair is loaded eviction will occur according to the cache eviction policy.
+ * This module comes with two loading cache implementations, the first {@link org.apache.druid.server.vectorizedlookup.cache.loading.OnHeapLoadingCache}is onheap backed by a Guava cache implementation, the second {@link org.apache.druid.server.vectorizedlookup.cache.loading.OffHeapLoadingCache}is MapDB offheap implementation.
+ * Both implementations offer various eviction strategies.
+ */
+public class LoadingLookup extends LookupExtractor
+{
+  private static final Logger LOGGER = new Logger(LoadingLookup.class);
+
+  private final DataFetcher<String, String> dataFetcher;
+  private final LoadingCache<String, String> loadingCache;
+  private final LoadingCache<String, List<String>> reverseLoadingCache;
+  private final AtomicBoolean isOpen;
+  private final String id = Integer.toHexString(System.identityHashCode(this));
+
+  public LoadingLookup(
+      DataFetcher dataFetcher,
+      LoadingCache<String, String> loadingCache,
+      LoadingCache<String, List<String>> reverseLoadingCache
+  )
+  {
+    this.dataFetcher = Preconditions.checkNotNull(dataFetcher, "lookup must have a DataFetcher");
+    this.loadingCache = Preconditions.checkNotNull(loadingCache, "loading lookup need a cache");
+    this.reverseLoadingCache = Preconditions.checkNotNull(reverseLoadingCache, "loading lookup need reverse cache");
+    this.isOpen = new AtomicBoolean(true);
+  }
+
+
+  @Override
+  public String apply(@Nullable final String key)
+  {
+    if (key == null) {
+      return null;
+    }
+
+    final String presentVal = this.loadingCache.getIfPresent(key);
+    if (presentVal != null) {
+      return presentVal;
+    }
+
+    final String val = this.dataFetcher.fetch(key);
+    if (val == null) {
+      return null;
+    }
+
+    this.loadingCache.putAll(Collections.singletonMap(key, val));
+
+    return val;
+  }
+
+  @Override
+  public List<String> unapply(@Nullable final String value)
+  {
+    if (value == null) {
+      return Collections.emptyList();
+    }
+    final List<String> retList;
+    try {
+      retList = reverseLoadingCache.get(value, new UnapplyCallable(value));
+      return retList;
+    }
+    catch (ExecutionException e) {
+      LOGGER.debug("list of keys not found for value [%s]", value);
+      return Collections.emptyList();
+    }
+  }
+
+  @Override
+  public boolean supportsAsMap()
+  {
+    return true;
+  }
+
+  @Override
+  public Map<String, String> asMap()
+  {
+    final Map<String, String> map = new HashMap<>();
+    Optional.ofNullable(this.dataFetcher.fetchAll())
+            .ifPresent(data -> data.forEach(entry -> map.put(entry.getKey(), entry.getValue())));
+    return map;
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    return LookupExtractionModule.getRandomCacheKey();
+  }
+
+  public synchronized void close()
+  {
+    if (isOpen.getAndSet(false)) {
+      LOGGER.info("Closing loading cache [%s]", id);
+      loadingCache.close();
+      reverseLoadingCache.close();
+    } else {
+      LOGGER.info("Closing already closed lookup");
+    }
+  }
+
+  public boolean isOpen()
+  {
+    return isOpen.get();
+  }
+
+  private class UnapplyCallable implements Callable<List<String>>
+  {
+    private final String value;
+
+    public UnapplyCallable(String value)
+    {
+      this.value = value;
+    }
+
+    @Override
+    public List<String> call()
+    {
+      return dataFetcher.reverseFetchKeys(value);
+    }
+  }
+
+  @Override
+  public String toString()
+  {
+    return "LoadingLookup{" +
+           "dataFetcher=" + dataFetcher +
+           ", id='" + id + '\'' +
+           '}';
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LoadingLookup.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LoadingLookup.java
@@ -76,17 +76,32 @@ public class LoadingLookup extends LookupExtractor
       return null;
     }
 
+    long cacheStartTime = System.currentTimeMillis();
     final String presentVal = this.loadingCache.getIfPresent(key);
+    long cacheEndTime = System.currentTimeMillis();
+
     if (presentVal != null) {
+      LOGGER.info("Unvectorized - Cache hit for key '%s' took %dms", key, cacheEndTime - cacheStartTime);
       return presentVal;
     }
 
+    LOGGER.info("Unvectorized - Cache miss for key '%s', cache lookup took %dms", key, cacheEndTime - cacheStartTime);
+
+    long dbStartTime = System.currentTimeMillis();
     final String val = this.dataFetcher.fetch(key);
+    long dbEndTime = System.currentTimeMillis();
+
     if (val == null) {
+      LOGGER.info("Unvectorized - Database query for key '%s' took %dms, returned null", key, dbEndTime - dbStartTime);
       return null;
     }
 
+    long putStartTime = System.currentTimeMillis();
     this.loadingCache.putAll(Collections.singletonMap(key, val));
+    long putEndTime = System.currentTimeMillis();
+
+    LOGGER.info("Unvectorized - Database query for key '%s' took %dms, cache put took %dms",
+        key, dbEndTime - dbStartTime, putEndTime - putStartTime);
 
     return val;
   }
@@ -94,24 +109,50 @@ public class LoadingLookup extends LookupExtractor
   @Override
   public Map<String, String> applyAll(Iterable<String> keys)
   {
+    long totalStartTime = System.currentTimeMillis();
+
     Set<String> keySet = Sets.newHashSet(keys);
+    keySet.remove(null);
     if (keySet.isEmpty()) {
       return Collections.emptyMap();
     }
 
-    Map<String, String> results = loadingCache.getAllPresent(keySet);
+    long cacheStartTime = System.currentTimeMillis();
+    Map<String, String> results = new HashMap<>(loadingCache.getAllPresent(keySet));
+    long cacheEndTime = System.currentTimeMillis();
+
+    int cacheHits = results.size();
+    int cacheMisses = keySet.size() - cacheHits;
+
+    LOGGER.info("Vectorized - Cache lookup for %d keys: %d hits, %d misses, took %dms",
+        keySet.size(), cacheHits, cacheMisses, cacheEndTime - cacheStartTime);
+
     keySet.removeAll(results.keySet());
     if (keySet.isEmpty()) {
+      long totalEndTime = System.currentTimeMillis();
+      LOGGER.info("Vectorized - All keys found in cache, total time: %dms", totalEndTime - totalStartTime);
       return results;
     }
 
+    long dbStartTime = System.currentTimeMillis();
     Iterable<Map.Entry<String, String>> fetchedResults = dataFetcher.fetch(keySet);
+    long dbEndTime = System.currentTimeMillis();
+
     Map<String, String> fetchedResultsMap = new HashMap<>();
     for (Map.Entry<String, String> entry : fetchedResults) {
       fetchedResultsMap.put(entry.getKey(), entry.getValue());
     }
+
+    long putStartTime = System.currentTimeMillis();
     loadingCache.putAll(fetchedResultsMap);
+    long putEndTime = System.currentTimeMillis();
+
     results.putAll(fetchedResultsMap);
+
+    long totalEndTime = System.currentTimeMillis();
+
+    LOGGER.info("Vectorized - Database query for %d keys took %dms, returned %d results, cache put took %dms, total time: %dms",
+        keySet.size(), dbEndTime - dbStartTime, fetchedResultsMap.size(), putEndTime - putStartTime, totalEndTime - totalStartTime);
 
     return results;
   }

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LoadingLookup.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LoadingLookup.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.server.vectorizedlookup;
 
-
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.lookup.LookupExtractor;
 import org.apache.druid.server.vectorizedlookup.cache.loading.LoadingCache;
@@ -31,14 +31,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Loading  lookup will load the key\value pair upon request on the key it self, the general algorithm is load key if absent.
- * Once the key/value  pair is loaded eviction will occur according to the cache eviction policy.
- * This module comes with two loading cache implementations, the first {@link org.apache.druid.server.vectorizedlookup.cache.loading.OnHeapLoadingCache}is onheap backed by a Guava cache implementation, the second {@link org.apache.druid.server.vectorizedlookup.cache.loading.OffHeapLoadingCache}is MapDB offheap implementation.
+ * Loading lookup will load the key\value pair upon request on the key it self,
+ * the general algorithm is load key if absent.
+ * Once the key/value pair is loaded eviction will occur according to the cache
+ * eviction policy.
+ * This module comes with two loading cache implementations, the first
+ * {@link org.apache.druid.server.vectorizedlookup.cache.loading.OnHeapLoadingCache}is
+ * onheap backed by a Guava cache implementation, the second
+ * {@link org.apache.druid.server.vectorizedlookup.cache.loading.OffHeapLoadingCache}is
+ * MapDB offheap implementation.
  * Both implementations offer various eviction strategies.
  */
 public class LoadingLookup extends LookupExtractor
@@ -54,15 +61,13 @@ public class LoadingLookup extends LookupExtractor
   public LoadingLookup(
       DataFetcher dataFetcher,
       LoadingCache<String, String> loadingCache,
-      LoadingCache<String, List<String>> reverseLoadingCache
-  )
+      LoadingCache<String, List<String>> reverseLoadingCache)
   {
     this.dataFetcher = Preconditions.checkNotNull(dataFetcher, "lookup must have a DataFetcher");
     this.loadingCache = Preconditions.checkNotNull(loadingCache, "loading lookup need a cache");
     this.reverseLoadingCache = Preconditions.checkNotNull(reverseLoadingCache, "loading lookup need reverse cache");
     this.isOpen = new AtomicBoolean(true);
   }
-
 
   @Override
   public String apply(@Nullable final String key)
@@ -84,6 +89,31 @@ public class LoadingLookup extends LookupExtractor
     this.loadingCache.putAll(Collections.singletonMap(key, val));
 
     return val;
+  }
+
+  @Override
+  public Map<String, String> applyAll(Iterable<String> keys)
+  {
+    Set<String> keySet = Sets.newHashSet(keys);
+    if (keySet.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> results = loadingCache.getAllPresent(keySet);
+    keySet.removeAll(results.keySet());
+    if (keySet.isEmpty()) {
+      return results;
+    }
+
+    Iterable<Map.Entry<String, String>> fetchedResults = dataFetcher.fetch(keySet);
+    Map<String, String> fetchedResultsMap = new HashMap<>();
+    for (Map.Entry<String, String> entry : fetchedResults) {
+      fetchedResultsMap.put(entry.getKey(), entry.getValue());
+    }
+    loadingCache.putAll(fetchedResultsMap);
+    results.putAll(fetchedResultsMap);
+
+    return results;
   }
 
   @Override
@@ -114,14 +144,14 @@ public class LoadingLookup extends LookupExtractor
   {
     final Map<String, String> map = new HashMap<>();
     Optional.ofNullable(this.dataFetcher.fetchAll())
-            .ifPresent(data -> data.forEach(entry -> map.put(entry.getKey(), entry.getValue())));
+        .ifPresent(data -> data.forEach(entry -> map.put(entry.getKey(), entry.getValue())));
     return map;
   }
 
   @Override
   public byte[] getCacheKey()
   {
-    return LookupExtractionModule.getRandomCacheKey();
+    return VectorizedLookupExtractionModule.getRandomCacheKey();
   }
 
   public synchronized void close()
@@ -160,8 +190,8 @@ public class LoadingLookup extends LookupExtractor
   public String toString()
   {
     return "LoadingLookup{" +
-           "dataFetcher=" + dataFetcher +
-           ", id='" + id + '\'' +
-           '}';
+        "dataFetcher=" + dataFetcher +
+        ", id='" + id + '\'' +
+        '}';
   }
 }

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LoadingLookupFactory.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LoadingLookupFactory.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@JsonTypeName("loadingLookup")
+@JsonTypeName("vectorizedLoadingLookup")
 public class LoadingLookupFactory implements LookupExtractorFactory
 {
   private static final Logger LOGGER = new Logger(LoadingLookupFactory.class);

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LoadingLookupFactory.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LoadingLookupFactory.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.query.lookup.LookupExtractorFactory;
+import org.apache.druid.query.lookup.LookupIntrospectHandler;
+import org.apache.druid.server.vectorizedlookup.cache.loading.LoadingCache;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@JsonTypeName("loadingLookup")
+public class LoadingLookupFactory implements LookupExtractorFactory
+{
+  private static final Logger LOGGER = new Logger(LoadingLookupFactory.class);
+
+  @JsonProperty("dataFetcher")
+  private final DataFetcher<String, String> dataFetcher;
+
+  @JsonProperty("loadingCacheSpec")
+  private final LoadingCache<String, String> loadingCache;
+
+  @JsonProperty("reverseLoadingCacheSpec")
+  private final LoadingCache<String, List<String>> reverseLoadingCache;
+
+  private final String id = Integer.toHexString(System.identityHashCode(this));
+  private final LoadingLookup loadingLookup;
+  private final AtomicBoolean started = new AtomicBoolean(false);
+
+  public LoadingLookupFactory(
+      @JsonProperty("dataFetcher") DataFetcher dataFetcher,
+      @JsonProperty("loadingCacheSpec") LoadingCache<String, String> loadingCache,
+      @JsonProperty("reverseLoadingCacheSpec") LoadingCache<String, List<String>> reverseLoadingCache
+  )
+  {
+    this(dataFetcher, loadingCache, reverseLoadingCache, new LoadingLookup(dataFetcher, loadingCache, reverseLoadingCache));
+  }
+
+  protected LoadingLookupFactory(
+      DataFetcher dataFetcher,
+      LoadingCache<String, String> loadingCache,
+      LoadingCache<String, List<String>> reverseLoadingCache,
+      LoadingLookup loadingLookup
+  )
+  {
+    this.dataFetcher = Preconditions.checkNotNull(dataFetcher);
+    this.loadingCache = Preconditions.checkNotNull(loadingCache);
+    this.reverseLoadingCache = Preconditions.checkNotNull(reverseLoadingCache);
+    this.loadingLookup = loadingLookup;
+  }
+
+  @Override
+  public synchronized boolean start()
+  {
+    if (!started.get()) {
+      started.set(loadingLookup.isOpen());
+      LOGGER.info("created loading lookup with id [%s]", id);
+    }
+    return started.get();
+  }
+
+  @Override
+  public synchronized boolean close()
+  {
+    if (started.getAndSet(false)) {
+      LOGGER.info("closing loading lookup [%s]", id);
+      loadingLookup.close();
+    }
+    return !started.get();
+  }
+
+  @Override
+  public boolean replaces(
+      @Nullable LookupExtractorFactory lookupExtractorFactory
+  )
+  {
+    if (lookupExtractorFactory == null) {
+      return true;
+    }
+    return !this.equals(lookupExtractorFactory);
+  }
+
+  @Nullable
+  @Override
+  public LookupIntrospectHandler getIntrospectHandler()
+  {
+    //not supported yet
+    return null;
+  }
+
+  @Override
+  public void awaitInitialization()
+  {
+    // LoadingLookupFactory does not have any initialization period as it fetches the key from loadingCache and DataFetcher as necessary.
+  }
+
+  @Override
+  public boolean isInitialized()
+  {
+    return true;
+  }
+  @Override
+  public LoadingLookup get()
+  {
+    return loadingLookup;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LoadingLookupFactory)) {
+      return false;
+    }
+
+    LoadingLookupFactory that = (LoadingLookupFactory) o;
+
+    if (dataFetcher != null ? !dataFetcher.equals(that.dataFetcher) : that.dataFetcher != null) {
+      return false;
+    }
+    if (loadingCache != null ? !loadingCache.equals(that.loadingCache) : that.loadingCache != null) {
+      return false;
+    }
+    return reverseLoadingCache != null
+           ? reverseLoadingCache.equals(that.reverseLoadingCache)
+           : that.reverseLoadingCache == null;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(dataFetcher, loadingCache, reverseLoadingCache);
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LookupExprMacro.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LookupExprMacro.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import com.google.inject.Inject;
+import org.apache.druid.math.expr.Evals;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.ExpressionType;
+import org.apache.druid.query.cache.CacheKeyBuilder;
+import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
+import org.apache.druid.query.lookup.RegisteredLookupExtractionFn;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class LookupExprMacro implements ExprMacroTable.ExprMacro
+{
+  private static final String FN_NAME = "vectorized_lookup";
+  private final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider;
+
+  @Inject
+  public LookupExprMacro(final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider)
+  {
+    this.lookupExtractorFactoryContainerProvider = lookupExtractorFactoryContainerProvider;
+  }
+
+  @Override
+  public String name()
+  {
+    return FN_NAME;
+  }
+
+  @Override
+  public Expr apply(final List<Expr> args)
+  {
+    validationHelperCheckArgumentRange(args, 2, 3);
+
+    final Expr arg = args.get(0);
+    final Expr lookupExpr = args.get(1);
+    final Expr replaceMissingValueWith = getReplaceMissingValueWith(args);
+
+    validationHelperCheckArgIsLiteral(lookupExpr, "second argument");
+    if (lookupExpr.getLiteralValue() == null) {
+      throw validationFailed("second argument must be a registered lookup name");
+    }
+
+    final String lookupName = lookupExpr.getLiteralValue().toString();
+    final RegisteredLookupExtractionFn extractionFn = new RegisteredLookupExtractionFn(
+        lookupExtractorFactoryContainerProvider,
+        lookupName,
+        false,
+        replaceMissingValueWith != null && replaceMissingValueWith.isLiteral()
+        ? Evals.asString(replaceMissingValueWith.getLiteralValue())
+        : null,
+        null,
+        null
+    );
+
+    class LookupExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
+    {
+      private LookupExpr(final List<Expr> args)
+      {
+        super(LookupExprMacro.this, args);
+      }
+
+      @Nonnull
+      @Override
+      public ExprEval eval(final ObjectBinding bindings)
+      {
+        return ExprEval.of(extractionFn.apply(arg.eval(bindings).asString()));
+      }
+
+      @Nullable
+      @Override
+      public ExpressionType getOutputType(InputBindingInspector inspector)
+      {
+        return ExpressionType.STRING;
+      }
+
+      @Override
+      public void decorateCacheKeyBuilder(CacheKeyBuilder builder)
+      {
+        builder.appendCacheable(extractionFn);
+      }
+    }
+
+    return new LookupExpr(args);
+  }
+
+  private Expr getReplaceMissingValueWith(final List<Expr> args)
+  {
+    if (args.size() > 2) {
+      final Expr missingValExpr = args.get(2);
+      validationHelperCheckArgIsLiteral(missingValExpr, "third argument");
+      return missingValExpr;
+    }
+    return null;
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LookupExprMacro.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LookupExprMacro.java
@@ -32,6 +32,7 @@ import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.lookup.LookupExtractor;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.RegisteredLookupExtractionFn;
+import org.apache.druid.java.util.common.logger.Logger;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,6 +44,7 @@ import java.util.stream.Collectors;
 public class LookupExprMacro implements ExprMacroTable.ExprMacro
 {
   private static final String FN_NAME = "vectorized_lookup";
+  private static final Logger LOGGER = new Logger(LookupExprMacro.class);
   private final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider;
 
   @Inject

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LookupExprMacro.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LookupExprMacro.java
@@ -25,13 +25,20 @@ import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionType;
+import org.apache.druid.math.expr.vector.ExprEvalObjectVector;
+import org.apache.druid.math.expr.vector.ExprEvalVector;
+import org.apache.druid.math.expr.vector.ExprVectorProcessor;
 import org.apache.druid.query.cache.CacheKeyBuilder;
+import org.apache.druid.query.lookup.LookupExtractor;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.RegisteredLookupExtractionFn;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class LookupExprMacro implements ExprMacroTable.ExprMacro
 {
@@ -70,11 +77,10 @@ public class LookupExprMacro implements ExprMacroTable.ExprMacro
         lookupName,
         false,
         replaceMissingValueWith != null && replaceMissingValueWith.isLiteral()
-        ? Evals.asString(replaceMissingValueWith.getLiteralValue())
-        : null,
+            ? Evals.asString(replaceMissingValueWith.getLiteralValue())
+            : null,
         null,
-        null
-    );
+        null);
 
     class LookupExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
@@ -98,6 +104,21 @@ public class LookupExprMacro implements ExprMacroTable.ExprMacro
       }
 
       @Override
+      public boolean canVectorize(InputBindingInspector inspector)
+      {
+        return arg.canVectorize(inspector);
+      }
+
+      @Override
+      public <T> ExprVectorProcessor<T> asVectorProcessor(VectorInputBindingInspector inspector)
+      {
+        return (ExprVectorProcessor<T>) new LookupVectorProcessor(
+            arg.asVectorProcessor(inspector),
+            extractionFn,
+            inspector.getMaxVectorSize());
+      }
+
+      @Override
       public void decorateCacheKeyBuilder(CacheKeyBuilder builder)
       {
         builder.appendCacheable(extractionFn);
@@ -115,5 +136,62 @@ public class LookupExprMacro implements ExprMacroTable.ExprMacro
       return missingValExpr;
     }
     return null;
+  }
+
+  /**
+   * Vector processor for lookup expressions that uses applyAll for batch
+   * processing
+   */
+  private static class LookupVectorProcessor implements ExprVectorProcessor<Object[]>
+  {
+    private final ExprVectorProcessor<Object[]> inputProcessor;
+    private final RegisteredLookupExtractionFn extractionFn;
+    private final int maxVectorSize;
+
+    public LookupVectorProcessor(
+        ExprVectorProcessor<Object[]> inputProcessor,
+        RegisteredLookupExtractionFn extractionFn,
+        int maxVectorSize)
+    {
+      this.inputProcessor = inputProcessor;
+      this.extractionFn = extractionFn;
+      this.maxVectorSize = maxVectorSize;
+    }
+
+    @Override
+    public ExprEvalVector<Object[]> evalVector(Expr.VectorInputBinding bindings)
+    {
+      final ExprEvalVector<Object[]> inputEval = inputProcessor.evalVector(bindings);
+      final Object[] inputValues = inputEval.values();
+
+      final List<String> inputs = Arrays.stream(inputValues)
+          .map(Evals::asString)
+          .collect(Collectors.toList());
+
+      final LookupExtractor lookupExtractor = extractionFn.getDelegate().getLookup();
+      final Map<String, String> lookupResults = lookupExtractor.applyAll(inputs);
+      final String defaultValue = extractionFn.getReplaceMissingValueWith();
+
+      final Object[] outputValues = inputs.stream()
+          .map(input -> {
+            String result = lookupResults.get(input);
+            return result != null ? result : defaultValue;
+          })
+          .toArray();
+
+      return new ExprEvalObjectVector(outputValues, ExpressionType.STRING);
+    }
+
+    @Override
+    public ExpressionType getOutputType()
+    {
+      return ExpressionType.STRING;
+    }
+
+    @Override
+    public int maxVectorSize()
+    {
+      return maxVectorSize;
+    }
   }
 }

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LookupExtractionModule.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LookupExtractionModule.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.java.util.common.StringUtils;
+
+import java.util.List;
+import java.util.UUID;
+
+public class LookupExtractionModule implements DruidModule
+{
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.<Module>of(
+        new SimpleModule("SingleCached-LoadingOrPolling-Lookup-Module")
+        {
+          @Override
+          public void setupModule(SetupContext context)
+          {
+            context.registerSubtypes(LoadingLookupFactory.class);
+            context.registerSubtypes(PollingLookupFactory.class);
+          }
+        }
+    );
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+  }
+
+  public static byte[] getRandomCacheKey()
+  {
+    return StringUtils.toUtf8(UUID.randomUUID().toString());
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LookupExtractionModule.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/LookupExtractionModule.java
@@ -23,8 +23,10 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.ExprMacroTable;
 
 import java.util.List;
 import java.util.UUID;
@@ -35,7 +37,7 @@ public class LookupExtractionModule implements DruidModule
   public List<? extends Module> getJacksonModules()
   {
     return ImmutableList.<Module>of(
-        new SimpleModule("SingleCached-LoadingOrPolling-Lookup-Module")
+        new SimpleModule("VectorizedLookup-LoadingOrPolling-Lookup-Module")
         {
           @Override
           public void setupModule(SetupContext context)
@@ -50,6 +52,10 @@ public class LookupExtractionModule implements DruidModule
   @Override
   public void configure(Binder binder)
   {
+    // Register the LookupExprMacro for expression functions
+    Multibinder.newSetBinder(binder, ExprMacroTable.ExprMacro.class)
+               .addBinding()
+               .to(LookupExprMacro.class);
   }
 
   public static byte[] getRandomCacheKey()

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/PollingLookup.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/PollingLookup.java
@@ -174,7 +174,7 @@ public class PollingLookup extends LookupExtractor
   @Override
   public byte[] getCacheKey()
   {
-    return LookupExtractionModule.getRandomCacheKey();
+    return VectorizedLookupExtractionModule.getRandomCacheKey();
   }
 
   private Runnable pollAndSwap()

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/PollingLookup.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/PollingLookup.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.query.lookup.LookupExtractor;
+import org.apache.druid.server.vectorizedlookup.cache.polling.OnHeapPollingCache;
+import org.apache.druid.server.vectorizedlookup.cache.polling.PollingCache;
+import org.apache.druid.server.vectorizedlookup.cache.polling.PollingCacheFactory;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class PollingLookup extends LookupExtractor
+{
+  private static final Logger LOGGER = new Logger(PollingLookup.class);
+
+  private final long pollPeriodMs;
+
+  private final DataFetcher dataFetcher;
+
+  private final PollingCacheFactory cacheFactory;
+
+  private final AtomicReference<CacheRefKeeper> refOfCacheKeeper = new AtomicReference<>();
+
+
+  private final ListeningScheduledExecutorService scheduledExecutorService;
+
+  private final AtomicBoolean isOpen = new AtomicBoolean(false);
+
+  private final ListenableFuture<?> pollFuture;
+
+  private final String id = Integer.toHexString(System.identityHashCode(this));
+
+  public PollingLookup(
+      long pollPeriodMs,
+      DataFetcher dataFetcher,
+      PollingCacheFactory cacheFactory
+  )
+  {
+    this.pollPeriodMs = pollPeriodMs;
+    this.dataFetcher = Preconditions.checkNotNull(dataFetcher);
+    this.cacheFactory = cacheFactory == null ? new OnHeapPollingCache.OnHeapPollingCacheProvider() : cacheFactory;
+    refOfCacheKeeper.set(new CacheRefKeeper(this.cacheFactory.makeOf(dataFetcher.fetchAll())));
+    if (pollPeriodMs > 0) {
+      scheduledExecutorService = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor(
+          Execs.makeThreadFactory("PollingLookup-" + StringUtils.encodeForFormat(id), Thread.MIN_PRIORITY)
+      ));
+      pollFuture = scheduledExecutorService.scheduleWithFixedDelay(
+          pollAndSwap(),
+          pollPeriodMs,
+          pollPeriodMs,
+          TimeUnit.MILLISECONDS
+      );
+    } else {
+      scheduledExecutorService = null;
+      pollFuture = null;
+    }
+    this.isOpen.set(true);
+  }
+
+
+  public void close()
+  {
+    LOGGER.info("Closing polling lookup [%s]", id);
+    synchronized (isOpen) {
+      isOpen.getAndSet(false);
+      if (pollFuture != null) {
+        pollFuture.cancel(true);
+        scheduledExecutorService.shutdown();
+      }
+      CacheRefKeeper cacheRefKeeper = refOfCacheKeeper.getAndSet(null);
+      if (cacheRefKeeper != null) {
+        cacheRefKeeper.doneWithIt();
+      }
+    }
+  }
+
+  @Override
+  @Nullable
+  public String apply(@Nullable String key)
+  {
+    if (key == null) {
+      return null;
+    }
+    final CacheRefKeeper cacheRefKeeper = refOfCacheKeeper.get();
+    if (cacheRefKeeper == null) {
+      throw new ISE("Cache reference is null");
+    }
+    final PollingCache cache = cacheRefKeeper.getAndIncrementRef();
+    try {
+      if (cache == null) {
+        // it must've been closed after swapping while I was getting it.  Try again.
+        return this.apply(key);
+      }
+      return (String) cache.get(key);
+    }
+    finally {
+      if (cache != null) {
+        cacheRefKeeper.doneWithIt();
+      }
+    }
+  }
+
+  @Override
+  public List<String> unapply(@Nullable final String value)
+  {
+    if (value == null) {
+      return Collections.emptyList();
+    }
+
+    CacheRefKeeper cacheRefKeeper = refOfCacheKeeper.get();
+    if (cacheRefKeeper == null) {
+      throw new ISE("pollingLookup id [%s] is closed", id);
+    }
+    PollingCache cache = cacheRefKeeper.getAndIncrementRef();
+    try {
+      if (cache == null) {
+        // it must've been closed after swapping while I was getting it.  Try again.
+        return this.unapply(value);
+      }
+      return cache.getKeys(value);
+    }
+    finally {
+      if (cache != null) {
+        cacheRefKeeper.doneWithIt();
+      }
+    }
+  }
+
+  @Override
+  public boolean supportsAsMap()
+  {
+    return false;
+  }
+
+  @Override
+  public Map<String, String> asMap()
+  {
+    throw new UnsupportedOperationException("Cannot get map view");
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    return LookupExtractionModule.getRandomCacheKey();
+  }
+
+  private Runnable pollAndSwap()
+  {
+    return new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        LOGGER.debug("Polling and swapping of PollingLookup [%s]", id);
+        CacheRefKeeper newCacheKeeper = new CacheRefKeeper(cacheFactory.makeOf(dataFetcher.fetchAll()));
+        CacheRefKeeper oldCacheKeeper = refOfCacheKeeper.getAndSet(newCacheKeeper);
+        if (oldCacheKeeper != null) {
+          oldCacheKeeper.doneWithIt();
+        }
+      }
+    };
+  }
+
+  @Override
+  public long estimateHeapFootprint()
+  {
+    PollingCache<?, ?> cache = null;
+
+    while (cache == null) {
+      final CacheRefKeeper cacheRefKeeper = refOfCacheKeeper.get();
+
+      if (cacheRefKeeper == null) {
+        // Closed.
+        return 0;
+      }
+
+      // If null, we'll do another run through the while loop.
+      cache = cacheRefKeeper.getAndIncrementRef();
+    }
+
+    return cache.estimateHeapFootprint();
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = (int) (pollPeriodMs ^ (pollPeriodMs >>> 32));
+    result = 31 * result + dataFetcher.hashCode();
+    result = 31 * result + cacheFactory.hashCode();
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PollingLookup)) {
+      return false;
+    }
+
+    PollingLookup that = (PollingLookup) o;
+
+    if (pollPeriodMs != that.pollPeriodMs) {
+      return false;
+    }
+    if (!dataFetcher.equals(that.dataFetcher)) {
+      return false;
+    }
+    return cacheFactory.equals(that.cacheFactory);
+
+  }
+
+  public boolean isOpen()
+  {
+    return isOpen.get();
+  }
+
+
+  protected static class CacheRefKeeper
+  {
+    private final PollingCache pollingCache;
+    private final AtomicLong refCounts = new AtomicLong(0L);
+
+    CacheRefKeeper(PollingCache pollingCache)
+    {
+      this.pollingCache = pollingCache;
+    }
+
+    PollingCache getAndIncrementRef()
+    {
+      synchronized (refCounts) {
+        if (refCounts.get() < 0) {
+          return null;
+        }
+        refCounts.incrementAndGet();
+        return pollingCache;
+      }
+    }
+
+    void doneWithIt()
+    {
+      synchronized (refCounts) {
+        if (refCounts.get() == 0) {
+          pollingCache.close();
+        }
+        refCounts.decrementAndGet();
+      }
+    }
+  }
+
+  @Override
+  public String toString()
+  {
+    return "PollingLookup{" +
+           "dataFetcher=" + dataFetcher +
+           ", id='" + id + '\'' +
+           '}';
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/PollingLookupFactory.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/PollingLookupFactory.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.query.lookup.LookupExtractorFactory;
+import org.apache.druid.query.lookup.LookupIntrospectHandler;
+import org.apache.druid.server.vectorizedlookup.cache.polling.PollingCacheFactory;
+import org.joda.time.Period;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@JsonTypeName("pollingLookup")
+public class PollingLookupFactory implements LookupExtractorFactory
+{
+  private static final Logger LOGGER = new Logger(PollingLookupFactory.class);
+
+  @JsonProperty("pollPeriod")
+  private final Period pollPeriod;
+
+  @JsonProperty("dataFetcher")
+  private final DataFetcher dataFetcher;
+
+  @JsonProperty("cacheProvider")
+  private final PollingCacheFactory cacheFactory;
+
+  private final PollingLookup pollingLookup;
+
+  private final AtomicBoolean started = new AtomicBoolean(false);
+
+  private final String id = Integer.toHexString(System.identityHashCode(this));
+
+  @JsonCreator
+  public PollingLookupFactory(
+      @JsonProperty("pollPeriod") Period pollPeriod,
+      @JsonProperty("dataFetcher") DataFetcher dataFetcher,
+      @JsonProperty("cacheFactory") PollingCacheFactory cacheFactory
+  )
+  {
+    this.pollPeriod = pollPeriod == null ? Period.ZERO : pollPeriod;
+    this.dataFetcher = dataFetcher;
+    this.cacheFactory = cacheFactory;
+    this.pollingLookup = new PollingLookup(
+        this.pollPeriod.toStandardDuration().getMillis(),
+        this.dataFetcher,
+        this.cacheFactory
+    );
+  }
+
+  @VisibleForTesting
+  protected PollingLookupFactory(
+      Period pollPeriod,
+      DataFetcher dataFetcher,
+      PollingCacheFactory pollingCacheFactory,
+      PollingLookup pollingLookup
+  )
+  {
+    this.pollPeriod = pollPeriod;
+    this.dataFetcher = dataFetcher;
+    this.cacheFactory = pollingCacheFactory;
+    this.pollingLookup = pollingLookup;
+  }
+
+  @Override
+  public boolean start()
+  {
+    synchronized (started) {
+      if (!started.get()) {
+        LOGGER.info("started polling lookup [%s]", id);
+        started.set(pollingLookup.isOpen());
+      }
+      return started.get();
+    }
+  }
+
+  @Override
+  public boolean close()
+  {
+    synchronized (started) {
+      if (started.getAndSet(false)) {
+        LOGGER.info("closing polling lookup [%s]", id);
+        pollingLookup.close();
+      }
+      return !started.get();
+    }
+  }
+
+  @Override
+  public boolean replaces(
+      @Nullable LookupExtractorFactory lookupExtractorFactory
+  )
+  {
+    if (lookupExtractorFactory == null) {
+      return true;
+    }
+
+    return !this.equals(lookupExtractorFactory);
+  }
+
+  @Nullable
+  @Override
+  public LookupIntrospectHandler getIntrospectHandler()
+  {
+    //not supported yet
+    return null;
+  }
+
+  @Override
+  public void awaitInitialization()
+  {
+  }
+
+  @Override
+  public boolean isInitialized()
+  {
+    return true;
+  }
+
+  @Override
+  public PollingLookup get()
+  {
+    return pollingLookup;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PollingLookupFactory)) {
+      return false;
+    }
+
+    PollingLookupFactory that = (PollingLookupFactory) o;
+
+    if (pollPeriod != null ? !pollPeriod.equals(that.pollPeriod) : that.pollPeriod != null) {
+      return false;
+    }
+    if (dataFetcher != null ? !dataFetcher.equals(that.dataFetcher) : that.dataFetcher != null) {
+      return false;
+    }
+    return cacheFactory != null
+           ? (that.cacheFactory != null
+              && cacheFactory.getClass() == (that.cacheFactory).getClass())
+           : that.cacheFactory == null;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(pollPeriod, dataFetcher, cacheFactory);
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/PollingLookupFactory.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/PollingLookupFactory.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@JsonTypeName("pollingLookup")
+@JsonTypeName("vectorizedPollingLookup")
 public class PollingLookupFactory implements LookupExtractorFactory
 {
   private static final Logger LOGGER = new Logger(PollingLookupFactory.class);

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/VectorizedLookupExtractionModule.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/VectorizedLookupExtractionModule.java
@@ -23,15 +23,15 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
-import com.google.inject.multibindings.Multibinder;
+import org.apache.druid.guice.ExpressionModule;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.sql.guice.SqlBindings;
 
 import java.util.List;
 import java.util.UUID;
 
-public class LookupExtractionModule implements DruidModule
+public class VectorizedLookupExtractionModule implements DruidModule
 {
   @Override
   public List<? extends Module> getJacksonModules()
@@ -52,10 +52,10 @@ public class LookupExtractionModule implements DruidModule
   @Override
   public void configure(Binder binder)
   {
-    // Register the LookupExprMacro for expression functions
-    Multibinder.newSetBinder(binder, ExprMacroTable.ExprMacro.class)
-               .addBinding()
-               .to(LookupExprMacro.class);
+    ExpressionModule.addExprMacro(binder, LookupExprMacro.class);
+
+    // Register the VECTORIZED_LOOKUP SQL function
+    SqlBindings.addOperatorConversion(binder, VectorizedLookupOperatorConversion.class);
   }
 
   public static byte[] getRandomCacheKey()

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/VectorizedLookupOperatorConversion.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/VectorizedLookupOperatorConversion.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import com.google.inject.Inject;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.math.expr.Evals;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
+import org.apache.druid.query.lookup.RegisteredLookupExtractionFn;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.OperatorConversions;
+import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+
+import java.util.List;
+
+public class VectorizedLookupOperatorConversion implements SqlOperatorConversion
+{
+  public static final SqlFunction SQL_FUNCTION = OperatorConversions
+      .operatorBuilder("VECTORIZED_LOOKUP")
+      .operandNames("expr", "lookupName", "replaceMissingValueWith")
+      .operandTypes(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)
+      .requiredOperandCount(2)
+      .literalOperands(1, 2)
+      .returnTypeNullable(SqlTypeName.VARCHAR)
+      .functionCategory(SqlFunctionCategory.STRING)
+      .build();
+
+  private final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider;
+
+  @Inject
+  public VectorizedLookupOperatorConversion(final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider)
+  {
+    this.lookupExtractorFactoryContainerProvider = lookupExtractorFactoryContainerProvider;
+  }
+
+  @Override
+  public SqlFunction calciteOperator()
+  {
+    return SQL_FUNCTION;
+  }
+
+  @Override
+  public DruidExpression toDruidExpression(
+      final PlannerContext plannerContext,
+      final RowSignature rowSignature,
+      final RexNode rexNode
+  )
+  {
+    return OperatorConversions.convertDirectCallWithExtraction(
+        plannerContext,
+        rowSignature,
+        rexNode,
+        "vectorized_lookup", // Use the vectorized lookup expression macro name
+        inputExpressions -> {
+          final DruidExpression arg = inputExpressions.get(0);
+          final Expr lookupNameExpr = plannerContext.parseExpression(inputExpressions.get(1).getExpression());
+          final String replaceMissingValueWith = getReplaceMissingValueWith(inputExpressions, plannerContext);
+          final String lookupName = (String) lookupNameExpr.getLiteralValue();
+
+          // Add the lookup name to the set of lookups to selectively load.
+          plannerContext.addLookupToLoad(lookupExtractorFactoryContainerProvider.getCanonicalLookupName(lookupName));
+
+          if (arg.isSimpleExtraction() && lookupNameExpr.isLiteral()) {
+            return arg.getSimpleExtraction().cascade(
+                new RegisteredLookupExtractionFn(
+                    lookupExtractorFactoryContainerProvider,
+                    lookupName,
+                    false,
+                    replaceMissingValueWith,
+                    null,
+                    // For vectorized lookups, we don't want to disable optimization at the extractionFn level
+                    // since the vectorized implementation handles optimization differently
+                    false
+                )
+            );
+          } else {
+            return null;
+          }
+        }
+    );
+  }
+
+  private String getReplaceMissingValueWith(
+      final List<DruidExpression> inputExpressions,
+      final PlannerContext plannerContext
+  )
+  {
+    if (inputExpressions.size() > 2) {
+      final Expr missingValExpr = plannerContext.parseExpression(inputExpressions.get(2).getExpression());
+      if (missingValExpr.isLiteral()) {
+        return Evals.asString(missingValExpr.getLiteralValue());
+      }
+    }
+    return null;
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/VectorizedLookupOperatorConversion.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/VectorizedLookupOperatorConversion.java
@@ -34,6 +34,8 @@ import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.List;
 
@@ -50,6 +52,7 @@ public class VectorizedLookupOperatorConversion implements SqlOperatorConversion
       .build();
 
   private final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider;
+  private static final Logger LOGGER = new Logger(VectorizedLookupOperatorConversion.class);
 
   @Inject
   public VectorizedLookupOperatorConversion(final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider)
@@ -70,6 +73,8 @@ public class VectorizedLookupOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
+    LOGGER.info("Processing VECTORIZED_LOOKUP SQL function\nStacktrace:\n%s",
+        ExceptionUtils.getStackTrace(new Exception()));
     return OperatorConversions.convertDirectCallWithExtraction(
         plannerContext,
         rowSignature,
@@ -81,10 +86,14 @@ public class VectorizedLookupOperatorConversion implements SqlOperatorConversion
           final String replaceMissingValueWith = getReplaceMissingValueWith(inputExpressions, plannerContext);
           final String lookupName = (String) lookupNameExpr.getLiteralValue();
 
+          LOGGER.info("VECTORIZED_LOOKUP SQL function details: lookupName=%s, replaceMissingValueWith=%s",
+              lookupName, replaceMissingValueWith);
+
           // Add the lookup name to the set of lookups to selectively load.
           plannerContext.addLookupToLoad(lookupExtractorFactoryContainerProvider.getCanonicalLookupName(lookupName));
 
           if (arg.isSimpleExtraction() && lookupNameExpr.isLiteral()) {
+            LOGGER.info("VECTORIZED_LOOKUP: Using simple extraction with literal lookup name");
             return arg.getSimpleExtraction().cascade(
                 new RegisteredLookupExtractionFn(
                     lookupExtractorFactoryContainerProvider,
@@ -98,6 +107,8 @@ public class VectorizedLookupOperatorConversion implements SqlOperatorConversion
                 )
             );
           } else {
+            LOGGER.info("VECTORIZED_LOOKUP: Not using simple extraction - arg.isSimpleExtraction=%s, lookupNameExpr.isLiteral=%s",
+                arg.isSimpleExtraction(), lookupNameExpr.isLiteral());
             return null;
           }
         }

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/LoadingCache.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/LoadingCache.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.loading;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.cache.CacheLoader;
+import com.google.common.util.concurrent.ExecutionError;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * A semi-persistent mapping from keys to values. Cache entries are added using
+ * {@link #get(Object, Callable)} and stored in the cache until either evicted or manually invalidated.
+ * <p>
+ * <p>Implementations of this interface are expected to be thread-safe, and can be safely accessed
+ * by multiple concurrent threads.
+ *
+ * This interface borrows ideas (and in some cases methods and javadoc) from Guava and JCache cache interface.
+ * Thanks Guava and JSR !
+ * We elected to make this as close as possible to JSR API like that users can build bridges between all the existing implementations of JSR.
+ */
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "guava", value = OnHeapLoadingCache.class),
+    @JsonSubTypes.Type(name = "mapDb", value = OffHeapLoadingCache.class)
+})
+public interface LoadingCache<K, V> extends Closeable
+{
+  /**
+   * @param key must not be null
+   * Returns the value associated with {@code key} in this cache, or {@code null} if there is no
+   * cached value for {@code key}.
+   * a cache miss should be counted if the key is missing.
+   */
+  @Nullable
+  V getIfPresent(K key);
+
+  /**
+   * Returns a map of the values associated with {@code keys} in this cache. The returned map will
+   * only contain entries which are already present in the cache.
+   */
+
+  Map<K, V> getAllPresent(Iterable<K> keys);
+
+  /**
+   * Returns the value associated with {@code key} in this cache, obtaining that value from
+   * {@code valueLoader} if necessary. No observable state associated with this cache is modified
+   * until loading completes.
+   *
+   * <p><b>Warning:</b> as with {@link CacheLoader#load}, {@code valueLoader} <b>must not</b> return
+   * {@code null}; it may either return a non-null value or throw an exception.
+   *
+   * @throws ExecutionException if a checked exception was thrown while loading the value
+   * @throws UncheckedExecutionException if an unchecked exception was thrown while loading the
+   *     value
+   * @throws ExecutionError if an error was thrown while loading the value
+   *
+   */
+  V get(K key, Callable<? extends V> valueLoader) throws ExecutionException;
+
+  /**
+   * Copies all of the mappings from the specified map to the cache. This method is used for bulk put.
+   *
+   * @throws IllegalStateException if the cache is {@link #isClosed()}
+   */
+
+  void putAll(Map<? extends K, ? extends V> m);
+
+  /**
+   * Discards any cached value for key {@code key}. Eviction can be lazy or eager.
+   *
+   * @throws IllegalStateException if the cache is {@link #isClosed()}
+   */
+  void invalidate(K key);
+
+  /**
+   * Discards any cached values for keys {@code keys}. Eviction can be lazy or eager.
+   *
+   * @throws IllegalStateException if the cache is {@link #isClosed()}
+   */
+  void invalidateAll(Iterable<K> keys);
+
+  /**
+   * Clears the contents of the cache.
+   *
+   * @throws IllegalStateException if the cache is {@link #isClosed()}
+   */
+  void invalidateAll();
+
+  /**
+   * @return Stats of the cache.
+   *
+   * @throws IllegalStateException if the cache is {@link #isClosed()}
+   */
+  LookupCacheStats getStats();
+
+  /**
+   * @return true if the Cache is closed
+   */
+  boolean isClosed();
+
+  /**
+   * Clean the used resources of the cache. Still not sure about cache lifecycle but as an initial design
+   * the namespace deletion event should call this method to clean up resources.
+   */
+
+  @Override
+  void close();
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/LookupCacheStats.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/LookupCacheStats.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.loading;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Statistics about the performance of a {@link LoadingCache}. Instances of this class are immutable.
+ * Cache statistics are incremented according to the following rules:
+ * <ul>
+ * <li>When a cache lookup encounters an existing cache entry {@code hitCount} is incremented.
+ * <li>When a cache lookup first encounters a missing cache entry {@code missCount} is incremented.
+ * <li>When an entry is evicted from the cache, {@code evictionCount} is incremented.
+ * </ul>
+ */
+public class LookupCacheStats
+{
+  private final long hitCount;
+  private final long missCount;
+  private final long evictionCount;
+
+  /**
+   * Constructs a new {@code CacheStats} instance.
+   */
+  public LookupCacheStats(long hitCount, long missCount, long evictionCount)
+  {
+    Preconditions.checkArgument(hitCount >= 0);
+    Preconditions.checkArgument(missCount >= 0);
+    Preconditions.checkArgument(evictionCount >= 0);
+
+    this.hitCount = hitCount;
+    this.missCount = missCount;
+    this.evictionCount = evictionCount;
+  }
+
+  /**
+   * Returns the number of times {@link LoadingCache} lookup methods have returned either a cached or
+   * uncached value. This is defined as {@code hitCount + missCount}.
+   */
+  public long requestCount()
+  {
+    return hitCount + missCount;
+  }
+
+  /**
+   * Returns the number of times {@link LoadingCache} lookup methods have returned a cached value.
+   */
+  public long hitCount()
+  {
+    return hitCount;
+  }
+
+  /**
+   * Returns the ratio of cache requests which were hits. This is defined as
+   * {@code hitCount / requestCount}, or {@code 1.0} when {@code requestCount == 0}.
+   * Note that {@code hitRate + missRate =~ 1.0}.
+   */
+  public double hitRate()
+  {
+    long requestCount = requestCount();
+    return (requestCount == 0) ? 1.0 : (double) hitCount / requestCount;
+  }
+
+  /**
+   * Returns the number of times {@link LoadingCache} lookup methods have returned an uncached (newly
+   * loaded) value, or null. Multiple concurrent calls to {@link LoadingCache} lookup methods on an absent
+   * value can result in multiple misses, all returning the results of a single cache load
+   * operation.
+   */
+  public long missCount()
+  {
+    return missCount;
+  }
+
+  /**
+   * Returns the ratio of cache requests which were misses. This is defined as
+   * {@code missCount / requestCount}, or {@code 0.0} when {@code requestCount == 0}.
+   * Note that {@code hitRate + missRate =~ 1.0}. Cache misses include all requests which
+   * weren't cache hits, including requests which resulted in either successful or failed loading
+   * attempts, and requests which waited for other threads to finish loading. It is thus the case
+   * that {@code missCount &gt;= loadSuccessCount + loadExceptionCount}. Multiple
+   * concurrent misses for the same key will result in a single load operation.
+   */
+  public double missRate()
+  {
+    long requestCount = requestCount();
+    return (requestCount == 0) ? 0.0 : (double) missCount / requestCount;
+  }
+
+
+  /**
+   * Returns the number of times an entry has been evicted. This count does not include manual
+   * {@linkplain LoadingCache#invalidate invalidations}.
+   */
+  public long evictionCount()
+  {
+    return evictionCount;
+  }
+
+  /**
+   * Returns a new {@code CacheStats} representing the difference between this {@code CacheStats}
+   * and {@code other}. Negative values, which aren't supported by {@code CacheStats} will be
+   * rounded up to zero.
+   */
+  public LookupCacheStats minus(LookupCacheStats other)
+  {
+    return new LookupCacheStats(
+        Math.max(0, hitCount - other.hitCount),
+        Math.max(0, missCount - other.missCount),
+        Math.max(0, evictionCount - other.evictionCount)
+    );
+  }
+
+  /**
+   * Returns a new {@code CacheStats} representing the sum of this {@code CacheStats}
+   * and {@code other}.
+   */
+  public LookupCacheStats plus(LookupCacheStats other)
+  {
+    return new LookupCacheStats(
+        hitCount + other.hitCount,
+        missCount + other.missCount,
+        evictionCount + other.evictionCount
+    );
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LookupCacheStats)) {
+      return false;
+    }
+
+    LookupCacheStats that = (LookupCacheStats) o;
+
+    if (hitCount != that.hitCount) {
+      return false;
+    }
+    if (missCount != that.missCount) {
+      return false;
+    }
+
+    return evictionCount == that.evictionCount;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = (int) (hitCount ^ (hitCount >>> 32));
+    result = 31 * result + (int) (missCount ^ (missCount >>> 32));
+    result = 31 * result + (int) (evictionCount ^ (evictionCount >>> 32));
+    return result;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "LookupCacheStats{" +
+           "hitCount=" + hitCount +
+           ", missCount=" + missCount +
+           ", evictionCount=" + evictionCount +
+           '}';
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/OffHeapLoadingCache.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/OffHeapLoadingCache.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.mapdb.Bind;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
@@ -37,6 +38,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class OffHeapLoadingCache<K, V> implements LoadingCache<K, V>
 {
+  private static final Logger log = new Logger(OffHeapLoadingCache.class);
   private static final DB DB = DBMaker.newMemoryDirectDB().transactionDisable().closeOnJvmShutdown().make();
 
   private final HTreeMap<K, V> cache;
@@ -91,17 +93,23 @@ public class OffHeapLoadingCache<K, V> implements LoadingCache<K, V>
                    .expireAfterAccess(this.expireAfterAccess, TimeUnit.MILLISECONDS)
                    .expireMaxSize(this.maxEntriesSize)
                    .make();
-    cache.modificationListenerAdd(new Bind.MapListener<>()
-    {
-      @Override
-      public void update(K key, V oldVal, V newVal)
+
+    try {
+      cache.modificationListenerAdd(new Bind.MapListener<>()
       {
-        if (oldVal != null && newVal == null) {
-          // eviction or remove call
-          evictionCount.getAndIncrement();
+        @Override
+        public void update(K key, V oldVal, V newVal)
+        {
+          if (oldVal != null && newVal == null) {
+            // eviction or remove call
+            evictionCount.getAndIncrement();
+          }
         }
-      }
-    });
+      });
+    } catch (NoClassDefFoundError e) {
+      // Log warning and continue without eviction counting
+      log.warn("Bind.MapListener not available, eviction counting disabled");
+    }
     this.closed.set(false);
   }
 

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/OffHeapLoadingCache.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/OffHeapLoadingCache.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.loading;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.ISE;
+import org.mapdb.Bind;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.HTreeMap;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class OffHeapLoadingCache<K, V> implements LoadingCache<K, V>
+{
+  private static final DB DB = DBMaker.newMemoryDirectDB().transactionDisable().closeOnJvmShutdown().make();
+
+  private final HTreeMap<K, V> cache;
+  private final AtomicLong hitCount = new AtomicLong(0);
+  private final AtomicLong missCount = new AtomicLong(0);
+  private final AtomicLong evictionCount = new AtomicLong(0);
+  private final AtomicBoolean closed = new AtomicBoolean(true);
+
+  /**
+   * Sets store size limit. Disk or memory space consumed be storage should not grow over this space.
+   * maximal size of store in GiB, if store is larger entries will start expiring
+   */
+  @JsonProperty
+  private final double maxStoreSize;
+
+  /**
+   * Sets maximal number of entries in this map.
+   * Less used entries will be expired and removed to make collection smaller
+   */
+  @JsonProperty
+  private final long maxEntriesSize;
+
+  /**
+   * Specifies that each entry should be automatically removed from the map once a fixed duration has elapsed after the entry's creation, or the most recent replacement of its value.
+   */
+  @JsonProperty
+  private final long expireAfterWrite;
+
+  /**
+   * Specifies that each entry should be automatically removed from the map once a fixed duration has elapsed after the entry's creation, the most recent replacement of its value, or its last access. Access time is reset by all map read and write operations
+   */
+  @JsonProperty
+  private final long expireAfterAccess;
+
+  private final String name = UUID.randomUUID().toString();
+
+  @JsonCreator
+  public OffHeapLoadingCache(
+      @JsonProperty("maxStoreSize") double maxStoreSize,
+      @JsonProperty("maxEntriesSize") long maxEntriesSize,
+      @JsonProperty("expireAfterWrite") long expireAfterWrite,
+      @JsonProperty("expireAfterAccess") long expireAfterAccess
+  )
+  {
+    this.maxStoreSize = maxStoreSize;
+    this.maxEntriesSize = maxEntriesSize;
+    this.expireAfterWrite = expireAfterWrite;
+    this.expireAfterAccess = expireAfterAccess;
+    this.cache = DB.createHashMap(name)
+                   .expireStoreSize(this.maxStoreSize)
+                   .expireAfterWrite(this.expireAfterWrite, TimeUnit.MILLISECONDS)
+                   .expireAfterAccess(this.expireAfterAccess, TimeUnit.MILLISECONDS)
+                   .expireMaxSize(this.maxEntriesSize)
+                   .make();
+    cache.modificationListenerAdd(new Bind.MapListener<>()
+    {
+      @Override
+      public void update(K key, V oldVal, V newVal)
+      {
+        if (oldVal != null && newVal == null) {
+          // eviction or remove call
+          evictionCount.getAndIncrement();
+        }
+      }
+    });
+    this.closed.set(false);
+  }
+
+  @Override
+  public V getIfPresent(K key)
+  {
+    V value = cache.get(key);
+    if (value == null) {
+      missCount.getAndIncrement();
+    } else {
+      hitCount.getAndIncrement();
+    }
+    return value;
+  }
+
+  @Override
+  public Map<K, V> getAllPresent(final Iterable<K> keys)
+  {
+    ImmutableMap.Builder builder = ImmutableMap.builder();
+    for (K key : keys) {
+      V value = getIfPresent(key);
+      if (value != null) {
+        builder.put(key, value);
+      }
+    }
+    return builder.build();
+  }
+
+  @Override
+  public V get(K key, final Callable<? extends V> valueLoader)
+  {
+    synchronized (key) {
+      V value = cache.get(key);
+      if (value != null) {
+        return value;
+      }
+      try {
+        value = valueLoader.call();
+        cache.put(key, value);
+        return value;
+      }
+      catch (Exception e) {
+        throw new ISE(e, "got an exception while loading key [%s]", key);
+      }
+    }
+  }
+
+
+  @Override
+  public void putAll(Map<? extends K, ? extends V> m)
+  {
+    cache.putAll(m);
+  }
+
+  @Override
+  public void invalidate(K key)
+  {
+    cache.remove(key);
+  }
+
+  @Override
+  public void invalidateAll(Iterable<K> keys)
+  {
+    for (K key : keys) {
+      invalidate(key);
+    }
+  }
+
+  @Override
+  public void invalidateAll()
+  {
+    cache.clear();
+  }
+
+  @Override
+  public LookupCacheStats getStats()
+  {
+    return new LookupCacheStats(hitCount.get(), missCount.get(), evictionCount.get());
+  }
+
+  @Override
+  public boolean isClosed()
+  {
+    return closed.get();
+  }
+
+  @Override
+  public void close()
+  {
+    if (!closed.getAndSet(true)) {
+      DB.delete(name);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof OffHeapLoadingCache)) {
+      return false;
+    }
+
+    OffHeapLoadingCache<?, ?> that = (OffHeapLoadingCache<?, ?>) o;
+
+    if (Double.compare(that.maxStoreSize, maxStoreSize) != 0) {
+      return false;
+    }
+    if (maxEntriesSize != that.maxEntriesSize) {
+      return false;
+    }
+    if (expireAfterWrite != that.expireAfterWrite) {
+      return false;
+    }
+    return expireAfterAccess == that.expireAfterAccess;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result;
+    long temp;
+    temp = Double.doubleToLongBits(maxStoreSize);
+    result = (int) (temp ^ (temp >>> 32));
+    result = 31 * result + (int) (maxEntriesSize ^ (maxEntriesSize >>> 32));
+    result = 31 * result + (int) (expireAfterWrite ^ (expireAfterWrite >>> 32));
+    result = 31 * result + (int) (expireAfterAccess ^ (expireAfterAccess >>> 32));
+    return result;
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/OffHeapLoadingCache.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/OffHeapLoadingCache.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.ISE;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.mapdb.Bind;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
@@ -38,7 +37,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class OffHeapLoadingCache<K, V> implements LoadingCache<K, V>
 {
-  private static final Logger log = new Logger(OffHeapLoadingCache.class);
   private static final DB DB = DBMaker.newMemoryDirectDB().transactionDisable().closeOnJvmShutdown().make();
 
   private final HTreeMap<K, V> cache;
@@ -93,23 +91,17 @@ public class OffHeapLoadingCache<K, V> implements LoadingCache<K, V>
                    .expireAfterAccess(this.expireAfterAccess, TimeUnit.MILLISECONDS)
                    .expireMaxSize(this.maxEntriesSize)
                    .make();
-
-    try {
-      cache.modificationListenerAdd(new Bind.MapListener<>()
+    cache.modificationListenerAdd(new Bind.MapListener<>()
+    {
+      @Override
+      public void update(K key, V oldVal, V newVal)
       {
-        @Override
-        public void update(K key, V oldVal, V newVal)
-        {
-          if (oldVal != null && newVal == null) {
-            // eviction or remove call
-            evictionCount.getAndIncrement();
-          }
+        if (oldVal != null && newVal == null) {
+          // eviction or remove call
+          evictionCount.getAndIncrement();
         }
-      });
-    } catch (NoClassDefFoundError e) {
-      // Log warning and continue without eviction counting
-      log.warn("Bind.MapListener not available, eviction counting disabled");
-    }
+      }
+    });
     this.closed.set(false);
   }
 

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/OnHeapLoadingCache.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/loading/OnHeapLoadingCache.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.loading;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.druid.java.util.common.logger.Logger;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+public class OnHeapLoadingCache<K, V> implements LoadingCache<K, V>
+{
+  private static final Logger log = new Logger(OnHeapLoadingCache.class);
+  private static final int DEFAULT_INITIAL_CAPACITY = 16;
+  //See com.google.common.cache.CacheBuilder#DEFAULT_CONCURRENCY_LEVEL
+  private static final int DEFAULT_CONCURRENCY_LEVEL = 4;
+
+  private final Cache<K, V> cache;
+  private final AtomicBoolean isClosed = new AtomicBoolean(false);
+  @JsonProperty
+  private final int concurrencyLevel;
+  @JsonProperty
+  private final int initialCapacity;
+  @JsonProperty
+  private final Long maximumSize;
+  @JsonProperty
+  private final Long expireAfterAccess;
+  @JsonProperty
+  private final Long expireAfterWrite;
+
+
+  /**
+   * @param concurrencyLevel  default to {@code DEFAULT_CONCURRENCY_LEVEL}
+   * @param initialCapacity   default to {@code DEFAULT_INITIAL_CAPACITY}
+   * @param maximumSize       Max number of entries that the cache can hold, When set to zero, elements will be evicted immediately after being loaded into the
+   *                          cache.
+   *                          When set to null, cache maximum size is infinity
+   * @param expireAfterAccess Specifies that each entry should be automatically removed from the cache once a fixed duration
+   *                          has elapsed after the entry's creation, the most recent replacement of its value, or its last
+   *                          access. Access time is reset by all cache read and write operations.
+   *                          No read-time-based eviction when set to null.
+   * @param expireAfterWrite  Specifies that each entry should be automatically removed from the cache once a fixed duration
+   *                          has elapsed after the entry's creation, or the most recent replacement of its value.
+   *                          No write-time-based eviction when set to null.
+   */
+  @JsonCreator
+  public OnHeapLoadingCache(
+      @JsonProperty("concurrencyLevel") int concurrencyLevel,
+      @JsonProperty("initialCapacity") int initialCapacity,
+      @JsonProperty("maximumSize") Long maximumSize,
+      @JsonProperty("expireAfterAccess") Long expireAfterAccess,
+      @JsonProperty("expireAfterWrite") Long expireAfterWrite
+  )
+  {
+    this.concurrencyLevel = concurrencyLevel <= 0 ? DEFAULT_CONCURRENCY_LEVEL : concurrencyLevel;
+    this.initialCapacity = initialCapacity <= 0 ? DEFAULT_INITIAL_CAPACITY : initialCapacity;
+    this.maximumSize = maximumSize;
+    this.expireAfterAccess = expireAfterAccess;
+    this.expireAfterWrite = expireAfterWrite;
+    CacheBuilder builder = CacheBuilder.newBuilder()
+                                       .concurrencyLevel(this.concurrencyLevel)
+                                       .initialCapacity(this.initialCapacity)
+                                       .recordStats();
+    if (this.expireAfterAccess != null) {
+      builder.expireAfterAccess(expireAfterAccess, TimeUnit.MILLISECONDS);
+    }
+    if (this.expireAfterWrite != null) {
+      builder.expireAfterWrite(this.expireAfterWrite, TimeUnit.MILLISECONDS);
+    }
+    if (this.maximumSize != null) {
+      builder.maximumSize(this.maximumSize);
+    }
+
+    this.cache = builder.build();
+
+    if (isClosed.getAndSet(false)) {
+      log.info("Guava Based OnHeapCache started with spec [%s]", cache.toString());
+    }
+  }
+
+
+  @Override
+  public V getIfPresent(K key)
+  {
+    return cache.getIfPresent(key);
+  }
+
+  @Override
+  public void putAll(Map<? extends K, ? extends V> m)
+  {
+    cache.putAll(m);
+  }
+
+
+  @Override
+  public Map<K, V> getAllPresent(Iterable<K> keys)
+  {
+    return cache.getAllPresent(keys);
+  }
+
+  @Override
+  public V get(K key, Callable<? extends V> valueLoader) throws ExecutionException
+  {
+    return cache.get(key, valueLoader);
+  }
+
+  @Override
+  public void invalidate(K key)
+  {
+    cache.invalidate(key);
+  }
+
+  @Override
+  public void invalidateAll(Iterable<K> keys)
+  {
+    cache.invalidateAll(keys);
+  }
+
+  @Override
+  public void invalidateAll()
+  {
+    cache.invalidateAll();
+    cache.cleanUp();
+  }
+
+  @Override
+  public LookupCacheStats getStats()
+  {
+    return new LookupCacheStats(
+        cache.stats().hitCount(),
+        cache.stats().missCount(),
+        cache.stats().evictionCount()
+    );
+  }
+
+  @Override
+  public boolean isClosed()
+  {
+    return isClosed.get();
+  }
+
+  @Override
+  public void close()
+  {
+    if (!isClosed.getAndSet(true)) {
+      cache.cleanUp();
+    }
+  }
+
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof OnHeapLoadingCache)) {
+      return false;
+    }
+
+    OnHeapLoadingCache<?, ?> that = (OnHeapLoadingCache<?, ?>) o;
+
+    if (concurrencyLevel != that.concurrencyLevel) {
+      return false;
+    }
+    if (initialCapacity != that.initialCapacity) {
+      return false;
+    }
+    if (maximumSize != null ? !maximumSize.equals(that.maximumSize) : that.maximumSize != null) {
+      return false;
+    }
+    if (expireAfterAccess != null
+        ? !expireAfterAccess.equals(that.expireAfterAccess)
+        : that.expireAfterAccess != null) {
+      return false;
+    }
+    return expireAfterWrite != null ? expireAfterWrite.equals(that.expireAfterWrite) : that.expireAfterWrite == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = concurrencyLevel;
+    result = 31 * result + initialCapacity;
+    result = 31 * result + (maximumSize != null ? maximumSize.hashCode() : 0);
+    result = 31 * result + (expireAfterAccess != null ? expireAfterAccess.hashCode() : 0);
+    result = 31 * result + (expireAfterWrite != null ? expireAfterWrite.hashCode() : 0);
+    return result;
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/polling/OffHeapPollingCache.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/polling/OffHeapPollingCache.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.polling;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.druid.java.util.common.StringUtils;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.HTreeMap;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+public class OffHeapPollingCache<K, V> implements PollingCache<K, V>
+{
+  private static final DB DB = DBMaker.newMemoryDirectDB().transactionDisable().closeOnJvmShutdown().make();
+
+  private final HTreeMap<K, V> mapCache;
+  private final HTreeMap<V, List<K>> reverseCache;
+  private final AtomicBoolean started = new AtomicBoolean(false);
+  private final String cacheName;
+  private final String reverseCacheName;
+
+  public OffHeapPollingCache(final Iterable<Map.Entry<K, V>> entries)
+  {
+    synchronized (started) {
+      this.cacheName = StringUtils.format("cache-%s", UUID.randomUUID());
+      this.reverseCacheName = StringUtils.format("reverseCache-%s", UUID.randomUUID());
+      mapCache = DB.createHashMap(cacheName).make();
+      reverseCache = DB.createHashMap(reverseCacheName).make();
+      ImmutableSet.Builder<V> setOfValuesBuilder = ImmutableSet.builder();
+      for (Map.Entry<K, V> entry : entries) {
+        mapCache.put(entry.getKey(), entry.getValue());
+        setOfValuesBuilder.add(entry.getValue());
+      }
+
+      final Set<V> setOfValues = setOfValuesBuilder.build();
+      reverseCache.putAll(Maps.asMap(
+          setOfValues,
+          new Function<>()
+          {
+            @Override
+            public List<K> apply(final V input)
+            {
+              return Lists.newArrayList(Maps.filterKeys(mapCache, new Predicate<>()
+              {
+                @Override
+                public boolean apply(K key)
+                {
+                  V retVal = mapCache.get(key);
+                  if (retVal == null) {
+                    return false;
+                  }
+                  return retVal.equals(input);
+                }
+              }).keySet());
+            }
+          }
+      ));
+      started.getAndSet(true);
+    }
+  }
+
+  @Override
+  public V get(K key)
+  {
+    return mapCache.get(key);
+  }
+
+  @Override
+  public List<K> getKeys(V value)
+  {
+    final List<K> listOfKey = reverseCache.get(value);
+    if (listOfKey == null) {
+      return Collections.emptyList();
+    }
+    return listOfKey;
+  }
+
+  @Override
+  public void close()
+  {
+    synchronized (started) {
+      if (started.getAndSet(false)) {
+        DB.delete(cacheName);
+        DB.delete(reverseCacheName);
+      }
+    }
+  }
+
+  public static class OffHeapPollingCacheProvider<K, V> implements PollingCacheFactory<K, V>
+  {
+    @Override
+    public PollingCache<K, V> makeOf(Iterable<Map.Entry<K, V>> entries)
+    {
+      return new OffHeapPollingCache<>(entries);
+    }
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/polling/OnHeapPollingCache.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/polling/OnHeapPollingCache.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.polling;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import org.apache.druid.query.extraction.MapLookupExtractor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OnHeapPollingCache<K, V> implements PollingCache<K, V>
+{
+  private final ImmutableMap<K, V> immutableMap;
+  private final ImmutableMap<V, List<K>> immutableReverseMap;
+
+
+  public OnHeapPollingCache(Iterable<Map.Entry<K, V>> entries)
+  {
+
+    if (entries == null) {
+      immutableMap = ImmutableMap.of();
+      immutableReverseMap = ImmutableMap.of();
+    } else {
+      ImmutableSet.Builder<V> setOfValuesBuilder = ImmutableSet.builder();
+      ImmutableMap.Builder<K, V> mapBuilder = ImmutableMap.builder();
+      for (Map.Entry<K, V> entry : entries) {
+        setOfValuesBuilder.add(entry.getValue());
+        mapBuilder.put(entry.getKey(), entry.getValue());
+      }
+      final Set<V> setOfValues = setOfValuesBuilder.build();
+      immutableMap = mapBuilder.build();
+      immutableReverseMap = ImmutableMap.copyOf(
+          Maps.asMap(
+              setOfValues,
+              val -> immutableMap
+                  .keySet()
+                  .stream()
+                  .filter(key -> {
+                    V retVal = immutableMap.get(key);
+                    return retVal != null && retVal.equals(val);
+                  })
+                  .collect(Collectors.toList())
+          )
+      );
+    }
+
+  }
+
+  @Override
+  public V get(K key)
+  {
+    return immutableMap.get(key);
+  }
+
+  @Override
+  public List<K> getKeys(final V value)
+  {
+    final List<K> listOfKeys = immutableReverseMap.get(value);
+    if (listOfKeys == null) {
+      return Collections.emptyList();
+    }
+    return listOfKeys;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public long estimateHeapFootprint()
+  {
+    return MapLookupExtractor.estimateHeapFootprint(((Map<String, String>) immutableMap).entrySet());
+  }
+
+  @Override
+  public void close()
+  {
+    //noop
+  }
+
+
+  public static class OnHeapPollingCacheProvider<K, V> implements PollingCacheFactory<K, V>
+  {
+    @Override
+    public PollingCache makeOf(Iterable<Map.Entry<K, V>> entries)
+    {
+      return new OnHeapPollingCache(entries);
+    }
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/polling/PollingCache.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/polling/PollingCache.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.polling;
+
+import java.util.List;
+
+public interface PollingCache<K, V>
+{
+  /**
+   * @param key Given key to lookup its value from the cache.
+   *
+   * @return Returns the value associated to the {@code key} or {@code null} if no value exist.
+   */
+  V get(K key);
+
+  /**
+   * @param value Given value to reverse lookup its keys.
+   *
+   * @return Returns a {@link List} of keys associated to the given {@code value} otherwise {@link java.util.Collections.EmptyList}
+   */
+  List<K> getKeys(V value);
+
+  /**
+   * close and clean the resources used by the cache
+   */
+  void close();
+
+  /**
+   * Estimated heap footprint of this object.
+   */
+  default long estimateHeapFootprint()
+  {
+    return 0;
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/polling/PollingCacheFactory.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/cache/polling/PollingCacheFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.polling;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.Map;
+
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = OnHeapPollingCache.OnHeapPollingCacheProvider.class)
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "onHeapPolling", value = OnHeapPollingCache.OnHeapPollingCacheProvider.class),
+    @JsonSubTypes.Type(name = "offHeapPolling", value = OffHeapPollingCache.OffHeapPollingCacheProvider.class)
+})
+public interface PollingCacheFactory<K, V>
+{
+  /**
+   * @param entries of keys and values used to populate the cache
+   *
+   * @return Returns a new {@link PollingCache} containing all the entries of {@code map}
+   */
+
+  PollingCache<K, V> makeOf(Iterable<Map.Entry<K, V>> entries);
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/jdbc/JdbcDataFetcher.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/jdbc/JdbcDataFetcher.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.jdbc;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.metadata.MetadataStorageConnectorConfig;
+import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
+import org.apache.druid.server.vectorizedlookup.DataFetcher;
+import org.apache.druid.utils.ConnectionUriUtils;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.TransactionCallback;
+import org.skife.jdbi.v2.exceptions.UnableToObtainConnectionException;
+import org.skife.jdbi.v2.util.StringMapper;
+
+import javax.annotation.Nullable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class JdbcDataFetcher implements DataFetcher<String, String>
+{
+  private static final Logger LOGGER = new Logger(JdbcDataFetcher.class);
+  private static final int DEFAULT_STREAMING_FETCH_SIZE = 1000;
+
+  @JsonProperty
+  private final MetadataStorageConnectorConfig connectorConfig;
+  @JsonProperty
+  private final String table;
+  @JsonProperty
+  private final String keyColumn;
+  @JsonProperty
+  private final String valueColumn;
+  @JsonProperty
+  private final int streamingFetchSize;
+
+  private final String fetchAllQuery;
+  private final String fetchQuery;
+  private final String reverseFetchQuery;
+  private final DBI dbi;
+
+  JdbcDataFetcher(
+      @JsonProperty("connectorConfig") MetadataStorageConnectorConfig connectorConfig,
+      @JsonProperty("table") String table,
+      @JsonProperty("keyColumn") String keyColumn,
+      @JsonProperty("valueColumn") String valueColumn,
+      @JsonProperty("streamingFetchSize") @Nullable Integer streamingFetchSize,
+      @JacksonInject JdbcAccessSecurityConfig securityConfig
+  )
+  {
+    this.connectorConfig = Preconditions.checkNotNull(connectorConfig, "connectorConfig");
+    this.streamingFetchSize = streamingFetchSize == null ? DEFAULT_STREAMING_FETCH_SIZE : streamingFetchSize;
+    // Check the properties in the connection URL. Note that JdbcDataFetcher doesn't use
+    // MetadataStorageConnectorConfig.getDbcpProperties(). If we want to use them,
+    // those DBCP properties should be validated using the same logic.
+    checkConnectionURL(connectorConfig.getConnectURI(), securityConfig);
+    this.table = Preconditions.checkNotNull(table, "table");
+    this.keyColumn = Preconditions.checkNotNull(keyColumn, "keyColumn");
+    this.valueColumn = Preconditions.checkNotNull(valueColumn, "valueColumn");
+
+    this.fetchAllQuery = StringUtils.format(
+        "SELECT %s, %s FROM %s",
+        this.keyColumn,
+        this.valueColumn,
+        this.table
+    );
+    this.fetchQuery = StringUtils.format(
+        "SELECT %s FROM %s WHERE %s = :val",
+        this.valueColumn,
+        this.table,
+        this.keyColumn
+    );
+    this.reverseFetchQuery = StringUtils.format(
+        "SELECT %s FROM %s WHERE %s = :val",
+        this.keyColumn,
+        this.table,
+        this.valueColumn
+    );
+    dbi = new DBI(
+        connectorConfig.getConnectURI(),
+        connectorConfig.getUser(),
+        connectorConfig.getPassword()
+    );
+    dbi.registerMapper(new KeyValueResultSetMapper(keyColumn, valueColumn));
+  }
+
+  /**
+   * Check the given URL whether it contains non-allowed properties.
+   *
+   * @see JdbcAccessSecurityConfig#getAllowedProperties()
+   * @see ConnectionUriUtils#tryParseJdbcUriParameters(String, boolean)
+   */
+  private static void checkConnectionURL(String url, JdbcAccessSecurityConfig securityConfig)
+  {
+    Preconditions.checkNotNull(url, "connectorConfig.connectURI");
+
+    if (!securityConfig.isEnforceAllowedProperties()) {
+      // You don't want to do anything with properties.
+      return;
+    }
+
+    ConnectionUriUtils.throwIfPropertiesAreNotAllowed(
+        ConnectionUriUtils.tryParseJdbcUriParameters(url, securityConfig.isAllowUnknownJdbcUrlFormat()),
+        securityConfig.getSystemPropertyPrefixes(),
+        securityConfig.getAllowedProperties()
+    );
+  }
+
+  @Override
+  public Iterable<Map.Entry<String, String>> fetchAll()
+  {
+    return inReadOnlyTransaction((handle, status) -> handle.createQuery(fetchAllQuery)
+                                                           .setFetchSize(streamingFetchSize)
+                                                           .map(new KeyValueResultSetMapper(keyColumn, valueColumn))
+                                                           .list());
+  }
+
+  @Override
+  public String fetch(final String key)
+  {
+    List<String> pairs = inReadOnlyTransaction(
+        (handle, status) -> handle.createQuery(fetchQuery)
+                                  .bind("val", key)
+                                  .map(StringMapper.FIRST)
+                                  .list()
+    );
+    if (pairs.isEmpty()) {
+      return null;
+    }
+    return pairs.get(0);
+  }
+
+  @Override
+  public Iterable<Map.Entry<String, String>> fetch(final Iterable<String> keys)
+  {
+    return runWithMissingJdbcJarHandler(
+        () -> {
+          QueryKeys queryKeys = dbi.onDemand(QueryKeys.class);
+          return queryKeys.findNamesForIds(Lists.newArrayList(keys), table, keyColumn, valueColumn);
+        }
+    );
+  }
+
+  @Override
+  public List<String> reverseFetchKeys(final String value)
+  {
+    return inReadOnlyTransaction((handle, status) -> handle.createQuery(reverseFetchQuery)
+                                                           .bind("val", value)
+                                                           .map(StringMapper.FIRST)
+                                                           .list());
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof JdbcDataFetcher)) {
+      return false;
+    }
+
+    JdbcDataFetcher that = (JdbcDataFetcher) o;
+
+    if (!connectorConfig.equals(that.connectorConfig)) {
+      return false;
+    }
+    if (!table.equals(that.table)) {
+      return false;
+    }
+    if (!keyColumn.equals(that.keyColumn)) {
+      return false;
+    }
+    return valueColumn.equals(that.valueColumn);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(connectorConfig, table, keyColumn, valueColumn);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "JdbcDataFetcher{" +
+           "table='" + table + '\'' +
+           ", keyColumn='" + keyColumn + '\'' +
+           ", valueColumn='" + valueColumn + '\'' +
+           '}';
+  }
+
+  private DBI getDbi()
+  {
+    return dbi;
+  }
+
+  private <T> T inReadOnlyTransaction(final TransactionCallback<T> callback)
+  {
+    return runWithMissingJdbcJarHandler(
+        () ->
+            getDbi().withHandle(
+                handle -> {
+                  final Connection connection = handle.getConnection();
+                  final boolean readOnly = connection.isReadOnly();
+                  connection.setReadOnly(true);
+                  try {
+                    return handle.inTransaction(callback);
+                  }
+                  finally {
+                    try {
+                      connection.setReadOnly(readOnly);
+                    }
+                    catch (SQLException e) {
+                      // at least try to log it so we don't swallow exceptions
+                      LOGGER.error(e, "Unable to reset connection read-only state");
+                    }
+                  }
+                }
+            )
+    );
+  }
+
+  private <T> T runWithMissingJdbcJarHandler(Supplier<T> supplier)
+  {
+    try {
+      return supplier.get();
+    }
+    catch (UnableToObtainConnectionException e) {
+      if (e.getMessage().contains("No suitable driver found")) {
+        throw new ISE(
+            e,
+            "JDBC driver JAR files missing in the classpath"
+        );
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/jdbc/JdbcDataFetcher.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/jdbc/JdbcDataFetcher.java
@@ -46,6 +46,27 @@ import java.util.function.Supplier;
 public class JdbcDataFetcher implements DataFetcher<String, String>
 {
   private static final Logger LOGGER = new Logger(JdbcDataFetcher.class);
+
+  /**
+   * Escape a SQL identifier (table or column name) to prevent SQL injection.
+   * This is a simple implementation that wraps the identifier in double quotes.
+   * For production use, consider using a more robust SQL escaping library.
+   */
+  private String escapeIdentifier(String identifier) {
+    if (identifier == null || identifier.trim().isEmpty()) {
+      throw new IllegalArgumentException("Identifier cannot be null or empty");
+    }
+    // Simple escaping: wrap in double quotes and escape any existing quotes
+    return "\"" + StringUtils.replace(identifier, "\"", "\"\"") + "\"";
+  }
+
+  private String escapeSqlValue(String value) {
+    if (value == null) {
+      return "NULL";
+    }
+    // Escape single quotes by doubling them
+    return StringUtils.replace(value, "'", "''");
+  }
   private static final int DEFAULT_STREAMING_FETCH_SIZE = 1000;
 
   @JsonProperty
@@ -106,6 +127,8 @@ public class JdbcDataFetcher implements DataFetcher<String, String>
         connectorConfig.getUser(),
         connectorConfig.getPassword()
     );
+    LOGGER.info("DBI object created successfully for table [%s]", table);
+
     dbi.registerMapper(new KeyValueResultSetMapper(keyColumn, valueColumn));
   }
 
@@ -134,6 +157,7 @@ public class JdbcDataFetcher implements DataFetcher<String, String>
   @Override
   public Iterable<Map.Entry<String, String>> fetchAll()
   {
+    LOGGER.info("Fetching all key-value pairs from table [%s]", table);
     return inReadOnlyTransaction((handle, status) -> handle.createQuery(fetchAllQuery)
                                                            .setFetchSize(streamingFetchSize)
                                                            .map(new KeyValueResultSetMapper(keyColumn, valueColumn))
@@ -143,6 +167,7 @@ public class JdbcDataFetcher implements DataFetcher<String, String>
   @Override
   public String fetch(final String key)
   {
+    LOGGER.info("Fetching value for key [%s] from table [%s]", key, table);
     List<String> pairs = inReadOnlyTransaction(
         (handle, status) -> handle.createQuery(fetchQuery)
                                   .bind("val", key)
@@ -150,8 +175,10 @@ public class JdbcDataFetcher implements DataFetcher<String, String>
                                   .list()
     );
     if (pairs.isEmpty()) {
+      LOGGER.info("No value found for key [%s] in table [%s]", key, table);
       return null;
     }
+    LOGGER.info("Found value for key [%s] in table [%s]", key, table);
     return pairs.get(0);
   }
 
@@ -160,8 +187,30 @@ public class JdbcDataFetcher implements DataFetcher<String, String>
   {
     return runWithMissingJdbcJarHandler(
         () -> {
-          QueryKeys queryKeys = dbi.onDemand(QueryKeys.class);
-          return queryKeys.findNamesForIds(Lists.newArrayList(keys), table, keyColumn, valueColumn);
+          // Convert Iterable to List for easier handling
+          List<String> keysList = Lists.newArrayList(keys);
+
+          // Build SQL with keys directly embedded and properly escaped
+          StringBuilder inClause = new StringBuilder();
+          for (int i = 0; i < keysList.size(); i++) {
+            if (i > 0) inClause.append(", ");
+            // Escape the key value for SQL injection protection
+            inClause.append("'").append(escapeSqlValue(keysList.get(i))).append("'");
+          }
+
+          String sql = StringUtils.format(
+              "SELECT %s, %s FROM %s WHERE %s IN (%s)",
+              escapeIdentifier(keyColumn),
+              escapeIdentifier(valueColumn),
+              escapeIdentifier(table),
+              escapeIdentifier(keyColumn),
+              inClause.toString()
+          );
+
+          // Execute the SQL using the connection pool like other methods
+          return inReadOnlyTransaction((handle, status) -> handle.createQuery(sql)
+              .map(new KeyValueResultSetMapper(keyColumn, valueColumn))
+              .list());
         }
     );
   }
@@ -169,6 +218,7 @@ public class JdbcDataFetcher implements DataFetcher<String, String>
   @Override
   public List<String> reverseFetchKeys(final String value)
   {
+    LOGGER.info("Reverse fetching keys for value [%s] from table [%s]", value, table);
     return inReadOnlyTransaction((handle, status) -> handle.createQuery(reverseFetchQuery)
                                                            .bind("val", value)
                                                            .map(StringMapper.FIRST)

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/jdbc/KeyValueResultSetMapper.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/jdbc/KeyValueResultSetMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.jdbc;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.AbstractMap;
+import java.util.Map;
+
+
+public class KeyValueResultSetMapper implements ResultSetMapper<Map.Entry<String, String>>
+{
+  private final String keyColumn;
+  private final String valueColumn;
+
+  public KeyValueResultSetMapper(String keyColumn, String valueColumn)
+  {
+    this.keyColumn = keyColumn;
+    this.valueColumn = valueColumn;
+  }
+
+  @Override
+  public Map.Entry<String, String> map(int index, ResultSet r, StatementContext ctx) throws SQLException
+  {
+    return new AbstractMap.SimpleEntry<>(r.getString(keyColumn), r.getString(valueColumn));
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/jdbc/QueryKeys.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/jdbc/QueryKeys.java
@@ -20,58 +20,16 @@
 package org.apache.druid.server.vectorizedlookup.jdbc;
 
 
-import com.google.common.collect.ImmutableSet;
-import org.skife.jdbi.v2.ContainerBuilder;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
-import org.skife.jdbi.v2.sqlobject.customizers.Define;
-import org.skife.jdbi.v2.sqlobject.customizers.RegisterContainerMapper;
-import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
-import org.skife.jdbi.v2.tweak.ContainerFactory;
 import org.skife.jdbi.v2.unstable.BindIn;
 
 import java.util.List;
 import java.util.Map;
 
-@UseStringTemplate3StatementLocator()
-@RegisterContainerMapper(QueryKeys.QueryKeysContainerFactory.class)
 public interface QueryKeys
 {
-  @SqlQuery("SELECT <keyColumn>, <valueColumn> FROM <table> WHERE <keyColumn> IN (<keys>)")
-  ImmutableSet<Map.Entry<String, String>> findNamesForIds(
-      @BindIn("keys") List<String> keys,
-      @Define("table") String table,
-      @Define("keyColumn") String keyColumn,
-      @Define("valueColumn") String valueColumn
+  @SqlQuery("SELECT key_column, value_column FROM lookup_table WHERE key_column IN (<keys>)")
+  List<Map.Entry<String, String>> findNamesForIds(
+      @BindIn("keys") List<String> keys
   );
-
-  class QueryKeysContainerFactory implements ContainerFactory<ImmutableSet<?>>
-  {
-    @Override
-    public boolean accepts(Class<?> type)
-    {
-      return ImmutableSet.class.isAssignableFrom(type);
-    }
-
-    @Override
-    public ContainerBuilder<ImmutableSet<?>> newContainerBuilderFor(Class<?> type)
-    {
-      return new ContainerBuilder<>()
-      {
-        final ImmutableSet.Builder<Object> builder = new ImmutableSet.Builder<>();
-
-        @Override
-        public ContainerBuilder<ImmutableSet<?>> add(final Object obj)
-        {
-          builder.add(obj);
-          return this;
-        }
-
-        @Override
-        public ImmutableSet<?> build()
-        {
-          return builder.build();
-        }
-      };
-    }
-  }
 }

--- a/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/jdbc/QueryKeys.java
+++ b/extensions-core/vectorized-lookups/src/main/java/org/apache/druid/server/vectorizedlookup/jdbc/QueryKeys.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.jdbc;
+
+
+import com.google.common.collect.ImmutableSet;
+import org.skife.jdbi.v2.ContainerBuilder;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.customizers.Define;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterContainerMapper;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+import org.skife.jdbi.v2.tweak.ContainerFactory;
+import org.skife.jdbi.v2.unstable.BindIn;
+
+import java.util.List;
+import java.util.Map;
+
+@UseStringTemplate3StatementLocator()
+@RegisterContainerMapper(QueryKeys.QueryKeysContainerFactory.class)
+public interface QueryKeys
+{
+  @SqlQuery("SELECT <keyColumn>, <valueColumn> FROM <table> WHERE <keyColumn> IN (<keys>)")
+  ImmutableSet<Map.Entry<String, String>> findNamesForIds(
+      @BindIn("keys") List<String> keys,
+      @Define("table") String table,
+      @Define("keyColumn") String keyColumn,
+      @Define("valueColumn") String valueColumn
+  );
+
+  class QueryKeysContainerFactory implements ContainerFactory<ImmutableSet<?>>
+  {
+    @Override
+    public boolean accepts(Class<?> type)
+    {
+      return ImmutableSet.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public ContainerBuilder<ImmutableSet<?>> newContainerBuilderFor(Class<?> type)
+    {
+      return new ContainerBuilder<>()
+      {
+        final ImmutableSet.Builder<Object> builder = new ImmutableSet.Builder<>();
+
+        @Override
+        public ContainerBuilder<ImmutableSet<?>> add(final Object obj)
+        {
+          builder.add(obj);
+          return this;
+        }
+
+        @Override
+        public ImmutableSet<?> build()
+        {
+          return builder.build();
+        }
+      };
+    }
+  }
+}

--- a/extensions-core/vectorized-lookups/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-core/vectorized-lookups/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.druid.server.lookup.LookupExtractionModule

--- a/extensions-core/vectorized-lookups/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-core/vectorized-lookups/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.druid.server.lookup.LookupExtractionModule
+org.apache.druid.server.vectorizedlookup.VectorizedLookupExtractionModule

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/CacheRefKeeperTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/CacheRefKeeperTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import org.apache.druid.server.vectorizedlookup.cache.polling.PollingCache;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CacheRefKeeperTest
+{
+
+  @Test
+  public void testGet()
+  {
+    PollingCache mockPollingCache = EasyMock.createStrictMock(PollingCache.class);
+    PollingLookup.CacheRefKeeper cacheRefKeeper = new PollingLookup.CacheRefKeeper(mockPollingCache);
+    Assert.assertEquals(mockPollingCache, cacheRefKeeper.getAndIncrementRef());
+  }
+
+  @Test
+  public void testDoneWithIt()
+  {
+    PollingCache mockPollingCache = EasyMock.createStrictMock(PollingCache.class);
+    PollingLookup.CacheRefKeeper cacheRefKeeper = new PollingLookup.CacheRefKeeper(mockPollingCache);
+    mockPollingCache.close();
+    EasyMock.expectLastCall().atLeastOnce();
+    EasyMock.replay(mockPollingCache);
+    cacheRefKeeper.doneWithIt();
+    EasyMock.verify(mockPollingCache);
+  }
+
+  @Test
+  public void testGetAfterDoneWithIt()
+  {
+    PollingCache mockPollingCache = EasyMock.createStrictMock(PollingCache.class);
+    PollingLookup.CacheRefKeeper cacheRefKeeper = new PollingLookup.CacheRefKeeper(mockPollingCache);
+    mockPollingCache.close();
+    EasyMock.expectLastCall().atLeastOnce();
+    EasyMock.replay(mockPollingCache);
+    cacheRefKeeper.doneWithIt();
+    EasyMock.verify(mockPollingCache);
+    Assert.assertEquals(null, cacheRefKeeper.getAndIncrementRef());
+    Assert.assertEquals(null, cacheRefKeeper.getAndIncrementRef());
+  }
+
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/LoadingLookupFactoryTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/LoadingLookupFactoryTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.query.lookup.LookupExtractorFactory;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.server.vectorizedlookup.cache.loading.LoadingCache;
+import org.apache.druid.server.vectorizedlookup.cache.loading.OffHeapLoadingCache;
+import org.apache.druid.server.vectorizedlookup.cache.loading.OnHeapLoadingCache;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+public class LoadingLookupFactoryTest
+{
+  private final DataFetcher dataFetcher = EasyMock.createMock(DataFetcher.class);
+  private final LoadingCache<String, String> lookupCache = EasyMock.createStrictMock(LoadingCache.class);
+  private final LoadingCache<String, List<String>> reverseLookupCache = EasyMock.createStrictMock(LoadingCache.class);
+  private final LoadingLookup loadingLookup = EasyMock.createMock(LoadingLookup.class);
+  private final LoadingLookupFactory loadingLookupFactory = new LoadingLookupFactory(
+      dataFetcher,
+      lookupCache,
+      reverseLookupCache,
+      loadingLookup
+  );
+
+  @Test
+  public void testStartStop()
+  {
+    EasyMock.expect(loadingLookup.isOpen()).andReturn(true).once();
+    loadingLookup.close();
+    EasyMock.expectLastCall().once();
+    EasyMock.replay(loadingLookup);
+    Assert.assertTrue(loadingLookupFactory.start());
+    loadingLookupFactory.awaitInitialization();
+    Assert.assertTrue(loadingLookupFactory.isInitialized());
+    Assert.assertTrue(loadingLookupFactory.close());
+    EasyMock.verify(loadingLookup);
+
+  }
+
+  @Test
+  public void testReplacesWithNull()
+  {
+    Assert.assertTrue(loadingLookupFactory.replaces(null));
+  }
+
+  @Test
+  public void testReplacesWithSame()
+  {
+    Assert.assertFalse(loadingLookupFactory.replaces(loadingLookupFactory));
+  }
+
+  @Test
+  public void testReplacesWithDifferent()
+  {
+    Assert.assertTrue(loadingLookupFactory.replaces(new LoadingLookupFactory(
+        EasyMock.createMock(DataFetcher.class),
+        lookupCache,
+        reverseLookupCache
+    )));
+    Assert.assertTrue(loadingLookupFactory.replaces(new LoadingLookupFactory(
+        dataFetcher,
+        EasyMock.createMock(LoadingCache.class),
+        reverseLookupCache
+    )));
+    Assert.assertTrue(loadingLookupFactory.replaces(new LoadingLookupFactory(
+        dataFetcher,
+        lookupCache,
+        EasyMock.createMock(LoadingCache.class)
+    )));
+  }
+
+
+  @Test
+  public void testGet()
+  {
+    Assert.assertEquals(loadingLookup, loadingLookupFactory.get());
+  }
+
+  @Test
+  public void testSerDeser() throws IOException
+  {
+    ObjectMapper mapper = TestHelper.makeJsonMapper();
+    LoadingLookupFactory loadingLookupFactory = new LoadingLookupFactory(
+        new MockDataFetcher(),
+        new OnHeapLoadingCache<>(
+            0,
+            100,
+            100L,
+            0L,
+            0L
+        ),
+        new OffHeapLoadingCache<>(
+            100,
+            100L,
+            0L,
+            0L
+        )
+    );
+
+    mapper.registerSubtypes(MockDataFetcher.class);
+    mapper.registerSubtypes(LoadingLookupFactory.class);
+    Assert.assertEquals(
+        loadingLookupFactory,
+        mapper.readerFor(LookupExtractorFactory.class)
+              .readValue(mapper.writeValueAsString(loadingLookupFactory))
+    );
+  }
+
+
+  @JsonTypeName("mock")
+  private static class MockDataFetcher implements DataFetcher
+  {
+    @JsonCreator
+    public MockDataFetcher()
+    {
+    }
+
+    @Override
+    public Iterable fetchAll()
+    {
+      return Collections.emptyMap().entrySet();
+    }
+
+    @Override
+    public Object fetch(Object key)
+    {
+      return null;
+    }
+
+    @Override
+    public Iterable fetch(Iterable keys)
+    {
+      return null;
+    }
+
+    @Override
+    public List reverseFetchKeys(Object value)
+    {
+      return null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+      return obj instanceof MockDataFetcher;
+    }
+  }
+
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/LoadingLookupTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/LoadingLookupTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import org.apache.druid.server.vectorizedlookup.cache.loading.LoadingCache;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+public class LoadingLookupTest extends InitializedNullHandlingTest
+{
+  DataFetcher dataFetcher = EasyMock.createMock(DataFetcher.class);
+  LoadingCache lookupCache = EasyMock.createMock(LoadingCache.class);
+  LoadingCache reverseLookupCache = EasyMock.createStrictMock(LoadingCache.class);
+  LoadingLookup loadingLookup = new LoadingLookup(dataFetcher, lookupCache, reverseLookupCache);
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testApplyEmptyOrNull()
+  {
+    EasyMock.expect(lookupCache.getIfPresent(EasyMock.eq("")))
+            .andReturn("empty").atLeastOnce();
+    EasyMock.replay(lookupCache);
+    Assert.assertEquals("empty", loadingLookup.apply(""));
+    Assert.assertNull(loadingLookup.apply(null));
+    EasyMock.verify(lookupCache);
+  }
+
+  @Test
+  public void testUnapplyNull()
+  {
+    Assert.assertEquals(Collections.emptyList(), loadingLookup.unapply(null));
+  }
+
+  @Test
+  public void testApply()
+  {
+    EasyMock.expect(lookupCache.getIfPresent(EasyMock.eq("key"))).andReturn("value").once();
+    EasyMock.replay(lookupCache);
+    Assert.assertEquals(ImmutableMap.of("key", "value"), loadingLookup.applyAll(ImmutableSet.of("key")));
+    EasyMock.verify(lookupCache);
+  }
+
+  @Test
+  public void testApplyWithNullValue()
+  {
+    EasyMock.expect(lookupCache.getIfPresent(EasyMock.eq("key"))).andReturn(null).once();
+    EasyMock.expect(dataFetcher.fetch("key")).andReturn(null).once();
+    EasyMock.replay(lookupCache, dataFetcher);
+    Assert.assertNull(loadingLookup.apply("key"));
+    EasyMock.verify(lookupCache, dataFetcher);
+  }
+
+  @Test
+  public void testApplyTriggersCacheMissAndSubsequentCacheHit()
+  {
+    Map<String, String> map = new HashMap<>();
+    map.put("key", "value");
+    EasyMock.expect(lookupCache.getIfPresent(EasyMock.eq("key"))).andReturn(null).once();
+    EasyMock.expect(dataFetcher.fetch("key")).andReturn("value").once();
+    lookupCache.putAll(map);
+    EasyMock.expectLastCall().andVoid();
+    EasyMock.expect(lookupCache.getIfPresent("key")).andReturn("value").once();
+    EasyMock.replay(lookupCache, dataFetcher);
+    Assert.assertEquals(loadingLookup.apply("key"), "value");
+    Assert.assertEquals(loadingLookup.apply("key"), "value");
+    EasyMock.verify(lookupCache, dataFetcher);
+  }
+
+  @Test
+  public void testUnapplyAll() throws ExecutionException
+  {
+    EasyMock.expect(reverseLookupCache.get(EasyMock.eq("value"), EasyMock.anyObject(Callable.class)))
+            .andReturn(Collections.singletonList("key"))
+            .once();
+    EasyMock.replay(reverseLookupCache);
+    Assert.assertEquals(
+        Collections.singletonList("key"),
+        Lists.newArrayList(loadingLookup.unapplyAll(ImmutableSet.of("value")))
+    );
+    EasyMock.verify(reverseLookupCache);
+  }
+
+  @Test
+  public void testClose()
+  {
+    lookupCache.close();
+    reverseLookupCache.close();
+    EasyMock.replay(lookupCache, reverseLookupCache);
+    loadingLookup.close();
+    EasyMock.verify(lookupCache, reverseLookupCache);
+  }
+
+  @Test
+  public void testUnApplyWithExecutionError() throws ExecutionException
+  {
+    EasyMock.expect(reverseLookupCache.get(EasyMock.eq("value"), EasyMock.anyObject(Callable.class)))
+            .andThrow(new ExecutionException(null))
+            .once();
+    EasyMock.replay(reverseLookupCache);
+    Assert.assertEquals(Collections.emptyList(), loadingLookup.unapply("value"));
+    EasyMock.verify(reverseLookupCache);
+  }
+
+  @Test
+  public void testGetCacheKey()
+  {
+    Assert.assertFalse(Arrays.equals(loadingLookup.getCacheKey(), loadingLookup.getCacheKey()));
+  }
+
+  @Test
+  public void testSupportsAsMap()
+  {
+    Assert.assertTrue(loadingLookup.supportsAsMap());
+  }
+
+  @Test
+  public void testAsMap()
+  {
+    final Map<String, String> fetchedData = new HashMap<>();
+    fetchedData.put("dummy", "test");
+    fetchedData.put("key", null);
+    fetchedData.put(null, "value");
+    EasyMock.expect(dataFetcher.fetchAll()).andReturn(fetchedData.entrySet());
+    EasyMock.replay(dataFetcher);
+    Assert.assertEquals(loadingLookup.asMap(), fetchedData);
+    EasyMock.verify(dataFetcher);
+  }
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/LoadingLookupTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/LoadingLookupTest.java
@@ -67,7 +67,7 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
   @Test
   public void testApply()
   {
-    EasyMock.expect(lookupCache.getIfPresent(EasyMock.eq("key"))).andReturn("value").once();
+    EasyMock.expect(lookupCache.getAllPresent(EasyMock.eq(ImmutableSet.of("key")))).andReturn(ImmutableMap.of("key", "value")).once();
     EasyMock.replay(lookupCache);
     Assert.assertEquals(ImmutableMap.of("key", "value"), loadingLookup.applyAll(ImmutableSet.of("key")));
     EasyMock.verify(lookupCache);

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/LookupExprMacroTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/LookupExprMacroTest.java
@@ -1,0 +1,573 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.commons.compress.utils.Sets;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.ExpressionType;
+import org.apache.druid.math.expr.InputBindings;
+import org.apache.druid.math.expr.Parser;
+import org.apache.druid.math.expr.vector.ExprEvalVector;
+import org.apache.druid.math.expr.vector.ExprVectorProcessor;
+import org.apache.druid.query.extraction.MapLookupExtractor;
+import org.apache.druid.query.lookup.LookupExtractor;
+import org.apache.druid.query.lookup.LookupExtractorFactory;
+import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
+import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
+import org.apache.druid.query.lookup.LookupIntrospectHandler;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class LookupExprMacroTest extends InitializedNullHandlingTest
+{
+  private static final Expr.ObjectBinding BINDINGS = InputBindings.forInputSuppliers(
+      ImmutableMap.<String, InputBindings.InputSupplier<?>>builder()
+          .put("x", InputBindings.inputSupplier(ExpressionType.STRING, () -> "foo"))
+          .put("y", InputBindings.inputSupplier(ExpressionType.STRING, () -> "bar"))
+          .put("z", InputBindings.inputSupplier(ExpressionType.STRING, () -> "baz"))
+          .build());
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  // Test setup for vectorized lookup macro
+  private static final String TEST_LOOKUP_NAME = "test_lookup";
+  private static final Map<String, String> TEST_LOOKUP_DATA = ImmutableMap.<String, String>builder()
+      .put("foo", "xfoo")
+      .put("bar", "xbar")
+      .put("baz", "xbaz")
+      .build();
+
+  private final LookupExprMacro macro = new LookupExprMacro(createTestLookupProvider());
+
+  @Test
+  public void testTooFewArgs()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Function[vectorized_lookup] requires 2 to 3 arguments");
+    macro.apply(Collections.emptyList());
+  }
+
+  @Test
+  public void testTooManyArgs()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Function[vectorized_lookup] requires 2 to 3 arguments");
+    List<Expr> args = Lists.newArrayList(
+        ExprEval.of("test").toExpr(),
+        ExprEval.of(TEST_LOOKUP_NAME).toExpr(),
+        ExprEval.of("default").toExpr(),
+        ExprEval.of("extra").toExpr());
+    macro.apply(args);
+  }
+
+  @Test
+  public void testNonLiteralLookupName()
+  {
+    expectedException.expect(org.apache.druid.math.expr.ExpressionValidationException.class);
+    expectedException.expectMessage("Function[vectorized_lookup] second argument argument must be a literal");
+    List<Expr> args = Lists.newArrayList(
+        ExprEval.of("test").toExpr(),
+        Parser.parse("x + 1", ExprMacroTable.nil()) // Non-literal Expr
+    );
+    macro.apply(args);
+  }
+
+  @Test
+  public void testValidCalls()
+  {
+    Assert.assertNotNull(macro.apply(getArgs(Lists.newArrayList("1", TEST_LOOKUP_NAME))));
+    Assert.assertNotNull(macro.apply(getArgs(Lists.newArrayList("null", TEST_LOOKUP_NAME))));
+    Assert.assertNotNull(macro.apply(getArgs(Lists.newArrayList("1", TEST_LOOKUP_NAME, null))));
+    Assert.assertNotNull(macro.apply(getArgs(Lists.newArrayList("1", TEST_LOOKUP_NAME, "N/A"))));
+  }
+
+  @Test
+  public void testBasicLookup()
+  {
+    assertExpr("vectorized_lookup(x, '" + TEST_LOOKUP_NAME + "')", "xfoo");
+  }
+
+  @Test
+  public void testLookupMissingValue()
+  {
+    assertExpr("vectorized_lookup(y, '" + TEST_LOOKUP_NAME + "', 'N/A')", "xbar");
+    assertExpr("vectorized_lookup('missing_key', '" + TEST_LOOKUP_NAME + "', 'N/A')", "N/A");
+    assertExpr("vectorized_lookup('missing_key', '" + TEST_LOOKUP_NAME + "', null)", null);
+  }
+
+  @Test
+  public void testLookupNotFound()
+  {
+    expectedException.expect(IllegalStateException.class);
+    expectedException.expectMessage("Lookup [nonexistent_lookup] not found");
+    assertExpr("vectorized_lookup(x, 'nonexistent_lookup')", null);
+  }
+
+  @Test
+  public void testCacheKeyChangesWhenLookupChanges()
+  {
+    final String expression = "vectorized_lookup(x, '" + TEST_LOOKUP_NAME + "')";
+    final Expr expr = Parser.parse(expression, createTestExprMacroTable(TEST_LOOKUP_DATA));
+    final Expr exprSameLookup = Parser.parse(expression, createTestExprMacroTable(TEST_LOOKUP_DATA));
+    final Expr exprChangedLookup = Parser.parse(
+        expression,
+        createTestExprMacroTable(ImmutableMap.of("x", "y", "a", "b")));
+
+    // same should have same cache key
+    Assert.assertArrayEquals(expr.getCacheKey(), exprSameLookup.getCacheKey());
+
+    // different should not have same key
+    final byte[] exprBytes = expr.getCacheKey();
+    final byte[] expr2Bytes = exprChangedLookup.getCacheKey();
+    if (exprBytes.length == expr2Bytes.length) {
+      // only check for equality if lengths are equal
+      boolean allEqual = true;
+      for (int i = 0; i < exprBytes.length; i++) {
+        allEqual = allEqual && (exprBytes[i] == expr2Bytes[i]);
+      }
+      Assert.assertFalse(allEqual);
+    }
+  }
+
+  @Test
+  public void testCacheKeyChangesWhenLookupChangesSubExpr()
+  {
+    final String expression = "concat(vectorized_lookup(x, '" + TEST_LOOKUP_NAME + "'))";
+    final Expr expr = Parser.parse(expression, createTestExprMacroTable(TEST_LOOKUP_DATA));
+    final Expr exprSameLookup = Parser.parse(expression, createTestExprMacroTable(TEST_LOOKUP_DATA));
+    final Expr exprChangedLookup = Parser.parse(
+        expression,
+        createTestExprMacroTable(ImmutableMap.of("x", "y", "a", "b")));
+
+    // same should have same cache key
+    Assert.assertArrayEquals(expr.getCacheKey(), exprSameLookup.getCacheKey());
+
+    // different should not have same key
+    final byte[] exprBytes = expr.getCacheKey();
+    final byte[] expr2Bytes = exprChangedLookup.getCacheKey();
+    if (exprBytes.length == expr2Bytes.length) {
+      // only check for equality if lengths are equal
+      boolean allEqual = true;
+      for (int i = 0; i < exprBytes.length; i++) {
+        allEqual = allEqual && (exprBytes[i] == expr2Bytes[i]);
+      }
+      Assert.assertFalse(allEqual);
+    }
+  }
+
+  // Vectorization-specific tests
+  @Test
+  public void testCanVectorize()
+  {
+    List<Expr> args = Lists.newArrayList(
+        ExprEval.of("test").toExpr(),
+        ExprEval.of(TEST_LOOKUP_NAME).toExpr());
+    Expr expr = macro.apply(args);
+
+    // Test that the expression can vectorize
+    Assert.assertTrue(expr.canVectorize(new TestInputBindingInspector()));
+  }
+
+  @Test
+  public void testVectorProcessorCreation()
+  {
+    List<Expr> args = Lists.newArrayList(
+        ExprEval.of("test").toExpr(),
+        ExprEval.of(TEST_LOOKUP_NAME).toExpr());
+    Expr expr = macro.apply(args);
+
+    // Test that we can create a vector processor
+    ExprVectorProcessor<Object[]> processor = expr.asVectorProcessor(new TestVectorInputBindingInspector());
+    Assert.assertNotNull(processor);
+    Assert.assertEquals(ExpressionType.STRING, processor.getOutputType());
+    Assert.assertEquals(512, processor.maxVectorSize()); // Default max vector size
+  }
+
+  @Test
+  public void testVectorProcessorEvaluation()
+  {
+    List<Expr> args = Lists.newArrayList(
+        Parser.parse("x", ExprMacroTable.nil()), // Use identifier expression for "x"
+        ExprEval.of(TEST_LOOKUP_NAME).toExpr());
+    Expr expr = macro.apply(args);
+
+    // Create a custom inspector that returns the actual data size
+    Expr.VectorInputBindingInspector inspector = new Expr.VectorInputBindingInspector()
+    {
+      @Override
+      public ExpressionType getType(String name)
+      {
+        return ExpressionType.STRING;
+      }
+
+      @Override
+      public int getMaxVectorSize()
+      {
+        return 4; // Match the test data size
+      }
+    };
+
+    ExprVectorProcessor<Object[]> processor = expr.asVectorProcessor(inspector);
+
+    // Create test vector bindings
+    TestVectorInputBinding bindings = new TestVectorInputBinding();
+    bindings.put("x", new Object[]{"foo", "bar", "baz", "missing_key"});
+
+    ExprEvalVector<Object[]> result = processor.evalVector(bindings);
+    Object[] values = result.values();
+
+    Assert.assertEquals(4, values.length);
+    Assert.assertEquals("xfoo", values[0]);
+    Assert.assertEquals("xbar", values[1]);
+    Assert.assertEquals("xbaz", values[2]);
+    Assert.assertEquals(null, values[3]); // missing key returns null
+  }
+
+  @Test
+  public void testVectorProcessorWithDefaultValue()
+  {
+    List<Expr> args = Lists.newArrayList(
+        Parser.parse("x", ExprMacroTable.nil()), // Use identifier expression for "x"
+        ExprEval.of(TEST_LOOKUP_NAME).toExpr(),
+        ExprEval.of("DEFAULT").toExpr());
+    Expr expr = macro.apply(args);
+
+    // Create a custom inspector that returns the actual data size
+    Expr.VectorInputBindingInspector inspector = new Expr.VectorInputBindingInspector()
+    {
+      @Override
+      public ExpressionType getType(String name)
+      {
+        return ExpressionType.STRING;
+      }
+
+      @Override
+      public int getMaxVectorSize()
+      {
+        return 4; // Match the test data size
+      }
+    };
+
+    ExprVectorProcessor<Object[]> processor = expr.asVectorProcessor(inspector);
+
+    // Create test vector bindings
+    TestVectorInputBinding bindings = new TestVectorInputBinding();
+    bindings.put("x", new Object[]{"foo", "bar", "baz", "missing_key"});
+
+    ExprEvalVector<Object[]> result = processor.evalVector(bindings);
+    Object[] values = result.values();
+
+    Assert.assertEquals(4, values.length);
+    Assert.assertEquals("xfoo", values[0]);
+    Assert.assertEquals("xbar", values[1]);
+    Assert.assertEquals("xbaz", values[2]);
+    Assert.assertEquals("DEFAULT", values[3]); // missing key returns default value
+  }
+
+  @Test
+  public void testVectorProcessorBatchProcessing()
+  {
+    List<Expr> args = Lists.newArrayList(
+        Parser.parse("x", ExprMacroTable.nil()), // Use identifier expression for "x"
+        ExprEval.of(TEST_LOOKUP_NAME).toExpr());
+    Expr expr = macro.apply(args);
+
+    // Create a custom inspector that returns the actual data size
+    Expr.VectorInputBindingInspector inspector = new Expr.VectorInputBindingInspector()
+    {
+      @Override
+      public ExpressionType getType(String name)
+      {
+        return ExpressionType.STRING;
+      }
+
+      @Override
+      public int getMaxVectorSize()
+      {
+        return 100; // Match the test data size
+      }
+    };
+
+    ExprVectorProcessor<Object[]> processor = expr.asVectorProcessor(inspector);
+
+    // Create test vector bindings with 100 identical values
+    TestVectorInputBinding bindings = new TestVectorInputBinding();
+    Object[] inputValues = new Object[100];
+    for (int i = 0; i < 100; i++) {
+      inputValues[i] = "foo";
+    }
+    bindings.put("x", inputValues);
+
+    ExprEvalVector<Object[]> result = processor.evalVector(bindings);
+    Object[] values = result.values();
+
+    Assert.assertEquals(100, values.length);
+    for (int i = 0; i < 100; i++) {
+      Assert.assertEquals("xfoo", values[i]);
+    }
+  }
+
+  // Helper methods
+  private void assertExpr(final String expression, final Object expectedResult)
+  {
+    final Expr expr = Parser.parse(expression, createTestExprMacroTable(TEST_LOOKUP_DATA));
+    Assert.assertEquals(expression, expectedResult, expr.eval(BINDINGS).value());
+
+    final Expr exprNotFlattened = Parser.parse(expression, createTestExprMacroTable(TEST_LOOKUP_DATA), false);
+    final Expr roundTripNotFlattened = Parser.parse(exprNotFlattened.stringify(),
+        createTestExprMacroTable(TEST_LOOKUP_DATA));
+    Assert.assertEquals(exprNotFlattened.stringify(), expectedResult, roundTripNotFlattened.eval(BINDINGS).value());
+
+    final Expr roundTrip = Parser.parse(expr.stringify(), createTestExprMacroTable(TEST_LOOKUP_DATA));
+    Assert.assertEquals(exprNotFlattened.stringify(), expectedResult, roundTrip.eval(BINDINGS).value());
+  }
+
+  private List<Expr> getArgs(List<Object> args)
+  {
+    return args.stream().map(a -> {
+      if (a != null && a instanceof String) {
+        return ExprEval.of(a.toString()).toExpr();
+      }
+      return ExprEval.bestEffortOf(null).toExpr();
+    }).collect(Collectors.toList());
+  }
+
+  private LookupExtractorFactoryContainerProvider createTestLookupProvider()
+  {
+    return new LookupExtractorFactoryContainerProvider()
+    {
+      @Override
+      public Set<String> getAllLookupNames()
+      {
+        return Sets.newHashSet(TEST_LOOKUP_NAME);
+      }
+
+      @Override
+      public Optional<LookupExtractorFactoryContainer> get(String lookupName)
+      {
+        if (TEST_LOOKUP_NAME.equals(lookupName)) {
+          return Optional.of(new TestLookupContainer(new MapLookupExtractor(TEST_LOOKUP_DATA, false)));
+        }
+        return Optional.empty();
+      }
+
+      @Override
+      public String getCanonicalLookupName(String lookupName)
+      {
+        return lookupName;
+      }
+    };
+  }
+
+  private ExprMacroTable createTestExprMacroTable(final Map<String, String> lookupData)
+  {
+    return new ExprMacroTable(Collections.singletonList(
+        new LookupExprMacro(createTestLookupProviderWithData(lookupData))));
+  }
+
+  private LookupExtractorFactoryContainerProvider createTestLookupProviderWithData(
+      final Map<String, String> lookupData)
+  {
+    return new LookupExtractorFactoryContainerProvider()
+    {
+      @Override
+      public Set<String> getAllLookupNames()
+      {
+        return Sets.newHashSet(TEST_LOOKUP_NAME);
+      }
+
+      @Override
+      public Optional<LookupExtractorFactoryContainer> get(String lookupName)
+      {
+        if (TEST_LOOKUP_NAME.equals(lookupName)) {
+          return Optional.of(new TestLookupContainer(new MapLookupExtractor(lookupData, false)));
+        }
+        return Optional.empty();
+      }
+
+      @Override
+      public String getCanonicalLookupName(String lookupName)
+      {
+        return lookupName;
+      }
+    };
+  }
+
+  // Test helper classes
+  private static class TestLookupContainer extends LookupExtractorFactoryContainer
+  {
+    public TestLookupContainer(final LookupExtractor theLookup)
+    {
+      super(
+          "v0",
+          new LookupExtractorFactory()
+          {
+            @Override
+            public boolean start()
+            {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean close()
+            {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean replaces(@Nullable final LookupExtractorFactory other)
+            {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public LookupIntrospectHandler getIntrospectHandler()
+            {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void awaitInitialization()
+            {
+            }
+
+            @Override
+            public boolean isInitialized()
+            {
+              return true;
+            }
+
+            @Override
+            public LookupExtractor get()
+            {
+              return theLookup;
+            }
+          });
+    }
+  }
+
+  private static class TestInputBindingInspector implements Expr.InputBindingInspector
+  {
+    @Override
+    public ExpressionType getType(String name)
+    {
+      return ExpressionType.STRING;
+    }
+  }
+
+  private static class TestVectorInputBindingInspector implements Expr.VectorInputBindingInspector
+  {
+    @Override
+    public ExpressionType getType(String name)
+    {
+      return ExpressionType.STRING;
+    }
+
+    @Override
+    public int getMaxVectorSize()
+    {
+      return 512;
+    }
+  }
+
+  private static class TestVectorInputBinding implements Expr.VectorInputBinding
+  {
+    private final Map<String, Object[]> bindings = new HashMap<>();
+
+    public void put(String name, Object[] values)
+    {
+      bindings.put(name, values);
+    }
+
+    @Override
+    public Object[] getObjectVector(String name)
+    {
+      return bindings.get(name);
+    }
+
+    @Override
+    public int getCurrentVectorSize()
+    {
+      return bindings.values().iterator().next().length;
+    }
+
+    @Override
+    public boolean[] getNullVector(String name)
+    {
+      Object[] vec = bindings.get(name);
+      boolean[] nulls = new boolean[vec != null ? vec.length : 0];
+      return nulls;
+    }
+
+    @Override
+    public double[] getDoubleVector(String name)
+    {
+      Object[] vec = bindings.get(name);
+      double[] arr = new double[vec != null ? vec.length : 0];
+      return arr;
+    }
+
+    @Override
+    public long[] getLongVector(String name)
+    {
+      Object[] vec = bindings.get(name);
+      long[] arr = new long[vec != null ? vec.length : 0];
+      return arr;
+    }
+
+    @Override
+    public int getMaxVectorSize()
+    {
+      if (bindings.isEmpty()) {
+        return 512;
+      }
+      return bindings.values().iterator().next().length;
+    }
+
+    @Override
+    public ExpressionType getType(String name)
+    {
+      return ExpressionType.STRING;
+    }
+
+    @Override
+    public int getCurrentVectorId()
+    {
+      return 0;
+    }
+  }
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/PollingLookupFactoryTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/PollingLookupFactoryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import org.easymock.EasyMock;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PollingLookupFactoryTest
+{
+
+  PollingLookup pollingLookup = EasyMock.createMock(PollingLookup.class);
+  PollingLookupFactory pollingLookupFactory = new PollingLookupFactory(Period.ZERO, null, null, pollingLookup);
+
+  @Test
+  public void testStart()
+  {
+    EasyMock.expect(pollingLookup.isOpen()).andReturn(true).once();
+    EasyMock.replay(pollingLookup);
+    Assert.assertTrue(pollingLookupFactory.start());
+    pollingLookupFactory.awaitInitialization();
+    Assert.assertTrue(pollingLookupFactory.isInitialized());
+    EasyMock.verify(pollingLookup);
+  }
+
+  @Test
+  public void testClose()
+  {
+    Assert.assertTrue(pollingLookupFactory.close());
+  }
+
+  @Test
+  public void testReplacesWithNull()
+  {
+    Assert.assertTrue(pollingLookupFactory.replaces(null));
+  }
+
+  @Test
+  public void testReplaces()
+  {
+    Assert.assertTrue(pollingLookupFactory.replaces(new PollingLookupFactory(
+        Period.millis(1),
+        null,
+        null,
+        pollingLookup
+    )));
+  }
+
+  @Test
+  public void testGet()
+  {
+    Assert.assertEquals(pollingLookup, pollingLookupFactory.get());
+  }
+
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/PollingLookupSerDeserTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/PollingLookupSerDeserTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.query.lookup.LookupExtractorFactory;
+import org.apache.druid.server.vectorizedlookup.cache.polling.OffHeapPollingCache;
+import org.apache.druid.server.vectorizedlookup.cache.polling.OnHeapPollingCache;
+import org.apache.druid.server.vectorizedlookup.cache.polling.PollingCacheFactory;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+
+@RunWith(Parameterized.class)
+public class PollingLookupSerDeserTest
+{
+  @Parameterized.Parameters
+  public static Collection<Object[]> inputData()
+  {
+    return Arrays.asList(new Object[][]{
+        {new OffHeapPollingCache.OffHeapPollingCacheProvider()}, {new OnHeapPollingCache.OnHeapPollingCacheProvider<>()}
+    });
+  }
+
+  private final PollingCacheFactory cacheFactory;
+  private final DataFetcher dataFetcher = new MockDataFetcher();
+
+  public PollingLookupSerDeserTest(PollingCacheFactory cacheFactory)
+  {
+    this.cacheFactory = cacheFactory;
+  }
+
+  @Test
+  public void testSerDeser() throws IOException
+  {
+    ObjectMapper mapper = new DefaultObjectMapper();
+    PollingLookupFactory pollingLookupFactory = new PollingLookupFactory(Period.ZERO, dataFetcher, cacheFactory);
+    mapper.registerSubtypes(MockDataFetcher.class);
+    mapper.registerSubtypes(PollingLookupFactory.class);
+    Assert.assertEquals(pollingLookupFactory, mapper.readerFor(LookupExtractorFactory.class).readValue(mapper.writeValueAsString(pollingLookupFactory)));
+  }
+
+  @JsonTypeName("mock")
+  private static class MockDataFetcher implements DataFetcher
+  {
+    @JsonCreator
+    public MockDataFetcher()
+    {
+    }
+
+    @Override
+    public Iterable<Map.Entry<Object, Object>> fetchAll()
+    {
+      return Collections.emptyMap().entrySet();
+    }
+
+    @Override
+    public Object fetch(Object key)
+    {
+      return null;
+    }
+
+    @Override
+    public Iterable fetch(Iterable keys)
+    {
+      return null;
+    }
+
+    @Override
+    public List reverseFetchKeys(Object value)
+    {
+      return null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+      return obj instanceof MockDataFetcher;
+    }
+  }
+
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/PollingLookupTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/PollingLookupTest.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.query.lookup.LookupExtractor;
+import org.apache.druid.server.vectorizedlookup.cache.polling.OffHeapPollingCache;
+import org.apache.druid.server.vectorizedlookup.cache.polling.OnHeapPollingCache;
+import org.apache.druid.server.vectorizedlookup.cache.polling.PollingCacheFactory;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(Parameterized.class)
+public class PollingLookupTest extends InitializedNullHandlingTest
+{
+  private static final Map<String, String> FIRST_LOOKUP_MAP = ImmutableMap.of(
+      "foo", "bar",
+      "bad", "bar",
+      "how about that", "foo",
+      "empty string", ""
+  );
+
+  private static final Map<String, String> SECOND_LOOKUP_MAP = ImmutableMap.of(
+      "new-foo", "new-bar",
+      "new-bad", "new-bar"
+  );
+
+  private static final long POLL_PERIOD = 1000L;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @JsonTypeName("mock")
+  private static class MockDataFetcher implements DataFetcher
+  {
+    private int callNumber = 0;
+
+    @Override
+    public Iterable fetchAll()
+    {
+      if (callNumber == 0) {
+        callNumber++;
+        return FIRST_LOOKUP_MAP.entrySet();
+      }
+      return SECOND_LOOKUP_MAP.entrySet();
+    }
+
+    @Nullable
+    @Override
+    public Object fetch(Object key)
+    {
+      return null;
+    }
+
+    @Override
+    public Iterable fetch(Iterable keys)
+    {
+      return null;
+    }
+
+    @Override
+    public List reverseFetchKeys(Object value)
+    {
+      return null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+      return obj instanceof MockDataFetcher;
+    }
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> inputData()
+  {
+    return Arrays.asList(new Object[][]{
+        {new OffHeapPollingCache.OffHeapPollingCacheProvider()},
+        {new OnHeapPollingCache.OnHeapPollingCacheProvider<>()}
+    });
+  }
+
+  private final PollingCacheFactory pollingCacheFactory;
+  private final DataFetcher dataFetcher = new MockDataFetcher();
+  private PollingLookup pollingLookup;
+
+  public PollingLookupTest(PollingCacheFactory pollingCacheFactory)
+  {
+    this.pollingCacheFactory = pollingCacheFactory;
+  }
+
+  @Before
+  public void setUp()
+  {
+    pollingLookup = new PollingLookup(POLL_PERIOD, dataFetcher, pollingCacheFactory);
+  }
+
+  @After
+  public void tearDown()
+  {
+    if (pollingLookup != null) {
+      pollingLookup.close();
+    }
+    pollingLookup = null;
+  }
+
+  @Test(expected = ISE.class)
+  public void testClose()
+  {
+    pollingLookup.close();
+    pollingLookup.apply("key");
+  }
+
+  @Test
+  public void testApply()
+  {
+    assertMapLookup(FIRST_LOOKUP_MAP, pollingLookup);
+  }
+
+  @Test(timeout = POLL_PERIOD * 3)
+  public void testApplyAfterDataChange() throws InterruptedException
+  {
+    assertMapLookup(FIRST_LOOKUP_MAP, pollingLookup);
+    Thread.sleep(POLL_PERIOD * 2);
+    assertMapLookup(SECOND_LOOKUP_MAP, pollingLookup);
+  }
+
+  @Test
+  public void testUnapply()
+  {
+    Assert.assertEquals(
+        "reverse lookup should match",
+        Sets.newHashSet("foo", "bad"),
+        Sets.newHashSet(pollingLookup.unapply("bar"))
+    );
+    Assert.assertEquals(
+        "reverse lookup should match",
+        Sets.newHashSet("how about that"),
+        Sets.newHashSet(pollingLookup.unapply("foo"))
+    );
+    Assert.assertEquals(
+        "reverse lookup should match",
+        Sets.newHashSet("empty string"),
+        Sets.newHashSet(pollingLookup.unapply(""))
+    );
+    Assert.assertEquals(
+        "reverse lookup of none existing value should be empty list",
+        Collections.emptyList(),
+        pollingLookup.unapply("does't exist")
+    );
+  }
+
+  @Test
+  public void testBulkApply()
+  {
+    Map<String, String> map = pollingLookup.applyAll(FIRST_LOOKUP_MAP.keySet());
+    Assert.assertEquals(FIRST_LOOKUP_MAP, map);
+  }
+
+  @Test
+  public void testGetCacheKey()
+  {
+    PollingLookup pollingLookup2 = new PollingLookup(1L, dataFetcher, pollingCacheFactory);
+    Assert.assertFalse(Arrays.equals(pollingLookup2.getCacheKey(), pollingLookup.getCacheKey()));
+  }
+
+  @Test
+  public void testSupportsAsMap()
+  {
+    Assert.assertFalse(pollingLookup.supportsAsMap());
+  }
+
+  @Test
+  public void testAsMap()
+  {
+    expectedException.expect(UnsupportedOperationException.class);
+    pollingLookup.asMap();
+  }
+
+  @Test
+  public void testEstimateHeapFootprint()
+  {
+    Assert.assertEquals(
+        pollingCacheFactory instanceof OffHeapPollingCache.OffHeapPollingCacheProvider ? 0L : 402L,
+        pollingLookup.estimateHeapFootprint()
+    );
+  }
+
+  private void assertMapLookup(Map<String, String> map, LookupExtractor lookup)
+  {
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      String key = entry.getKey();
+      String val = entry.getValue();
+      Assert.assertEquals("non-null check", val, lookup.apply(key));
+    }
+  }
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/VectorizedLookupOperatorConversionTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/VectorizedLookupOperatorConversionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup;
+
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VectorizedLookupOperatorConversionTest
+{
+  @Test
+  public void testSqlFunctionDefinition()
+  {
+    LookupExtractorFactoryContainerProvider mockProvider = EasyMock.createMock(LookupExtractorFactoryContainerProvider.class);
+    VectorizedLookupOperatorConversion conversion = new VectorizedLookupOperatorConversion(mockProvider);
+
+    SqlFunction sqlFunction = conversion.calciteOperator();
+    Assert.assertNotNull(sqlFunction);
+    Assert.assertEquals("VECTORIZED_LOOKUP", sqlFunction.getName());
+  }
+
+  @Test
+  public void testStaticSqlFunction()
+  {
+    SqlFunction sqlFunction = VectorizedLookupOperatorConversion.SQL_FUNCTION;
+    Assert.assertNotNull(sqlFunction);
+    Assert.assertEquals("VECTORIZED_LOOKUP", sqlFunction.getName());
+  }
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/cache/loading/LoadingCacheTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/cache/loading/LoadingCacheTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.loading;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+@RunWith(Parameterized.class)
+public class LoadingCacheTest
+{
+  private static final ImmutableMap IMMUTABLE_MAP = ImmutableMap.of("key", "value");
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> inputData()
+  {
+    return Arrays.asList(new Object[][]{
+        {new OnHeapLoadingCache<>(4, 1000, null, null, null)},
+        {new OffHeapLoadingCache(0, 0L, 0L, 0L)}
+    });
+  }
+
+  private final LoadingCache loadingCache;
+
+  public LoadingCacheTest(LoadingCache loadingCache)
+  {
+    this.loadingCache = loadingCache;
+  }
+
+  @Before
+  public void setUp()
+  {
+    Assert.assertFalse(loadingCache.isClosed());
+    loadingCache.putAll(IMMUTABLE_MAP);
+  }
+
+  @After
+  public void tearDown()
+  {
+    loadingCache.invalidateAll();
+  }
+
+  @Test
+  public void testGetIfPresent()
+  {
+    Assert.assertNull(loadingCache.getIfPresent("not there"));
+    Assert.assertEquals(IMMUTABLE_MAP.get("key"), loadingCache.getIfPresent("key"));
+  }
+
+  @Test
+  public void testGetAllPresent()
+  {
+    Assert.assertEquals(IMMUTABLE_MAP, loadingCache.getAllPresent(IMMUTABLE_MAP.keySet()));
+  }
+
+  @Test
+  public void testPut() throws ExecutionException
+  {
+    loadingCache.get("key2", new Callable()
+    {
+      @Override
+      public Object call()
+      {
+        return "value2";
+      }
+    });
+    Assert.assertEquals("value2", loadingCache.getIfPresent("key2"));
+  }
+
+  @Test
+  public void testInvalidate() throws ExecutionException
+  {
+    loadingCache.get("key2", new Callable()
+    {
+      @Override
+      public Object call()
+      {
+        return "value2";
+      }
+    });
+    Assert.assertEquals("value2", loadingCache.getIfPresent("key2"));
+    loadingCache.invalidate("key2");
+    Assert.assertEquals(null, loadingCache.getIfPresent("key2"));
+  }
+
+  @Test
+  public void testInvalidateAll() throws ExecutionException
+  {
+    loadingCache.get("key2", new Callable()
+    {
+      @Override
+      public Object call()
+      {
+        return "value2";
+      }
+    });
+    Assert.assertEquals("value2", loadingCache.getIfPresent("key2"));
+    loadingCache.invalidateAll(Collections.singletonList("key2"));
+    Assert.assertEquals(null, loadingCache.getIfPresent("key2"));
+  }
+
+  @Test
+  public void testInvalidateAll1() throws ExecutionException
+  {
+    loadingCache.invalidateAll();
+    loadingCache.get("key2", new Callable()
+    {
+      @Override
+      public Object call()
+      {
+        return "value2";
+      }
+    });
+    Assert.assertEquals(loadingCache.getAllPresent(IMMUTABLE_MAP.keySet()), Collections.emptyMap());
+  }
+
+  @Test
+  public void testGetStats()
+  {
+    Assert.assertTrue(loadingCache.getStats() != null && loadingCache.getStats() instanceof LookupCacheStats);
+  }
+
+  @Test
+  public void testIsClosed()
+  {
+    Assert.assertFalse(loadingCache.isClosed());
+  }
+
+  @Test
+  public void testSerDeser() throws IOException
+  {
+    ObjectMapper mapper = new DefaultObjectMapper();
+    Assert.assertEquals(loadingCache, mapper.readerFor(LoadingCache.class).readValue(mapper.writeValueAsString(loadingCache)));
+    Assert.assertEquals(loadingCache.hashCode(), mapper.readerFor(LoadingCache.class).readValue(mapper.writeValueAsString(loadingCache)).hashCode());
+  }
+
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/cache/loading/OffHeapLoadingCacheTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/cache/loading/OffHeapLoadingCacheTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.loading;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OffHeapLoadingCacheTest
+{
+  @Test
+  public void testClose()
+  {
+    LoadingCache loadingCache = new OffHeapLoadingCache<>(1000L, 1000L, 0L, 0L);
+    loadingCache.close();
+    Assert.assertTrue(loadingCache.isClosed());
+  }
+
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/cache/loading/OnHeapLoadingCacheTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/cache/loading/OnHeapLoadingCacheTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.cache.loading;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OnHeapLoadingCacheTest
+{
+  @Test
+  public void testIsClosed()
+  {
+    OnHeapLoadingCache onHeapLookupLoadingCache = new OnHeapLoadingCache(4, 15, 100L, 10L, 10L);
+    onHeapLookupLoadingCache.close();
+    Assert.assertTrue(onHeapLookupLoadingCache.isClosed());
+  }
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/jdbc/JdbcDataFetcherTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/jdbc/JdbcDataFetcherTest.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.jdbc;
+
+import com.fasterxml.jackson.databind.InjectableValues.Std;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.metadata.MetadataStorageConnectorConfig;
+import org.apache.druid.metadata.TestDerbyConnector;
+import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
+import org.apache.druid.server.vectorizedlookup.DataFetcher;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.skife.jdbi.v2.Handle;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.Map;
+
+public class JdbcDataFetcherTest extends InitializedNullHandlingTest
+{
+  private static final String TABLE_NAME = "tableName";
+  private static final String KEY_COLUMN = "keyColumn";
+  private static final String VALUE_COLUMN = "valueColumn";
+
+  public static class FetchTest
+  {
+    @Rule
+    public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
+
+    private Handle handle;
+
+    private JdbcDataFetcher jdbcDataFetcher;
+
+    private static final Map<String, String> LOOKUP_MAP = ImmutableMap.of(
+        "foo", "bar",
+        "bad", "bar",
+        "how about that", "foo",
+        "empty string", ""
+    );
+
+    @Before
+    public void setUp()
+    {
+      jdbcDataFetcher = new JdbcDataFetcher(
+          derbyConnectorRule.getMetadataConnectorConfig(),
+          "tableName",
+          "keyColumn",
+          "valueColumn",
+          100,
+          new JdbcAccessSecurityConfig()
+      );
+
+      handle = derbyConnectorRule.getConnector().getDBI().open();
+      Assert.assertEquals(
+          0,
+          handle.createStatement(
+              StringUtils.format(
+                  "CREATE TABLE %s (%s VARCHAR(64), %s VARCHAR(64))",
+                  TABLE_NAME,
+                  KEY_COLUMN,
+                  VALUE_COLUMN
+              )
+          ).setQueryTimeout(1).execute()
+      );
+      handle.createStatement(StringUtils.format("TRUNCATE TABLE %s", TABLE_NAME)).setQueryTimeout(1).execute();
+
+      for (Map.Entry<String, String> entry : LOOKUP_MAP.entrySet()) {
+        insertValues(entry.getKey(), entry.getValue(), handle);
+      }
+      handle.commit();
+    }
+
+    @After
+    public void tearDown()
+    {
+      handle.createStatement("DROP TABLE " + TABLE_NAME).setQueryTimeout(1).execute();
+      handle.close();
+    }
+
+    @Test
+    public void testFetch()
+    {
+      Assert.assertEquals("null check", null, jdbcDataFetcher.fetch("baz"));
+      assertMapLookup(LOOKUP_MAP, jdbcDataFetcher);
+    }
+
+    @Test
+    public void testFetchAll()
+    {
+      ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
+      jdbcDataFetcher.fetchAll().forEach(mapBuilder::put);
+      Assert.assertEquals("maps should match", LOOKUP_MAP, mapBuilder.build());
+    }
+
+    @Test
+    public void testFetchKeys()
+    {
+      ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
+      jdbcDataFetcher.fetch(LOOKUP_MAP.keySet()).forEach(mapBuilder::put);
+      Assert.assertEquals(LOOKUP_MAP, mapBuilder.build());
+    }
+
+    @Test
+    public void testReverseFetch()
+    {
+      Assert.assertEquals(
+          "reverse lookup should match",
+          Sets.newHashSet("foo", "bad"),
+          Sets.newHashSet(jdbcDataFetcher.reverseFetchKeys("bar"))
+      );
+      Assert.assertEquals(
+          "reverse lookup should match",
+          Sets.newHashSet("how about that"),
+          Sets.newHashSet(jdbcDataFetcher.reverseFetchKeys("foo"))
+      );
+      Assert.assertEquals(
+          "reverse lookup should match",
+          Sets.newHashSet("empty string"),
+          Sets.newHashSet(jdbcDataFetcher.reverseFetchKeys(""))
+      );
+      Assert.assertEquals(
+          "reverse lookup of none existing value should be empty list",
+          Collections.emptyList(),
+          jdbcDataFetcher.reverseFetchKeys("does't exist")
+      );
+    }
+
+    @Test
+    public void testSerDesr() throws IOException
+    {
+      final JdbcAccessSecurityConfig securityConfig = new JdbcAccessSecurityConfig();
+      JdbcDataFetcher jdbcDataFetcher = new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig(),
+          "table",
+          "keyColumn",
+          "ValueColumn",
+          100,
+          securityConfig
+      );
+      DefaultObjectMapper mapper = new DefaultObjectMapper();
+      mapper.setInjectableValues(new Std().addValue(JdbcAccessSecurityConfig.class, securityConfig));
+      String jdbcDataFetcherSer = mapper.writeValueAsString(jdbcDataFetcher);
+      Assert.assertEquals(jdbcDataFetcher, mapper.readerFor(DataFetcher.class).readValue(jdbcDataFetcherSer));
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void assertMapLookup(Map<String, String> map, DataFetcher dataFetcher)
+    {
+      for (Map.Entry<String, String> entry : map.entrySet()) {
+        String key = entry.getKey();
+        String val = entry.getValue();
+        Assert.assertEquals("non-null check", val, dataFetcher.fetch(key));
+      }
+    }
+
+    private void insertValues(final String key, final String val, Handle handle)
+    {
+      final String query;
+      handle.createStatement(
+          StringUtils.format("DELETE FROM %s WHERE %s='%s'", TABLE_NAME, KEY_COLUMN, key)
+      ).setQueryTimeout(1).execute();
+      query = StringUtils.format(
+          "INSERT INTO %s (%s, %s) VALUES ('%s', '%s')",
+          TABLE_NAME,
+          KEY_COLUMN, VALUE_COLUMN,
+          key, val
+      );
+      Assert.assertEquals(1, handle.createStatement(query).setQueryTimeout(1).execute());
+      handle.commit();
+    }
+  }
+
+  public static class MissingJdbcJarTest
+  {
+    private static final MetadataStorageConnectorConfig MISSING_METADATA_STORAGE_CONNECTOR_CONFIG =
+        createMissingMetadataStorageConnectorConfig();
+    private static final String KEY = "key";
+
+    private JdbcDataFetcher target;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setUp()
+    {
+      target = new JdbcDataFetcher(
+          MISSING_METADATA_STORAGE_CONNECTOR_CONFIG,
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          null,
+          new JdbcAccessSecurityConfig()
+      );
+    }
+
+    @Test
+    public void testFetchAll()
+    {
+      test(() -> target.fetchAll());
+    }
+
+    @Test
+    public void testFetch()
+    {
+      test(() -> target.fetch(Collections.singleton(KEY)));
+    }
+
+    @Test
+    public void testFetchKeys()
+    {
+      test(() -> target.fetch(Collections.singleton(KEY)));
+    }
+
+    @Test
+    public void testReverseFetch()
+    {
+      test(() -> target.reverseFetchKeys(KEY));
+    }
+
+    private void test(Runnable runnable)
+    {
+      exception.expect(IllegalStateException.class);
+      exception.expectMessage("JDBC driver JAR files missing in the classpath");
+
+      runnable.run();
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static MetadataStorageConnectorConfig createMissingMetadataStorageConnectorConfig()
+    {
+      String type = "mydb";
+      String json = "{\"connectURI\":\"jdbc:" + type + "://localhost:3306/\"}";
+      try {
+        return new ObjectMapper().readValue(json, MetadataStorageConnectorConfig.class);
+      }
+      catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+  }
+}

--- a/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/jdbc/JdbcDataFetcherUrlCheckTest.java
+++ b/extensions-core/vectorized-lookups/src/test/java/org/apache/druid/server/vectorizedlookup/jdbc/JdbcDataFetcherUrlCheckTest.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.vectorizedlookup.jdbc;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.metadata.MetadataStorageConnectorConfig;
+import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Set;
+
+public class JdbcDataFetcherUrlCheckTest
+{
+  private static final String TABLE_NAME = "tableName";
+  private static final String KEY_COLUMN = "keyColumn";
+  private static final String VALUE_COLUMN = "valueColumn";
+
+  public static class MySqlTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testCreateInstanceWhenUrlHasOnlyAllowedProperties()
+    {
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql://localhost:3306/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testThrowWhenUrlHasDisallowedPropertiesWhenEnforcingAllowedProperties()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]");
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql://localhost:3306/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenUrlHasDisallowedPropertiesWhenNotEnforcingAllowedProperties()
+    {
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mysql://localhost:3306/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return false;
+            }
+          }
+      );
+    }
+  }
+
+  public static class PostgreSqlTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testCreateInstanceWhenUrlHasOnlyAllowedProperties()
+    {
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testThrowWhenUrlHasDisallowedPropertiesWhenEnforcingAllowedProperties()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]");
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://localhost:5432/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenUrlHasDisallowedPropertiesWhenNotEnforcingAllowedProperties()
+    {
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://localhost:5432/db?invalid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return false;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testWhenInvalidUrlFormat()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Invalid URL format for PostgreSQL: [jdbc:postgresql://invalid-url::3006]");
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:postgresql://invalid-url::3006";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+  }
+
+  public static class UnknownSchemeTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testThrowWhenUnknownFormatIsNotAllowed()
+    {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Unknown JDBC connection scheme: mydb");
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mydb://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isAllowUnknownJdbcUrlFormat()
+            {
+              return false;
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+
+    @Test
+    public void testSkipUrlParsingWhenUnknownFormatIsAllowed()
+    {
+      new JdbcDataFetcher(
+          new MetadataStorageConnectorConfig()
+          {
+            @Override
+            public String getConnectURI()
+            {
+              return "jdbc:mydb://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+            }
+          },
+          TABLE_NAME,
+          KEY_COLUMN,
+          VALUE_COLUMN,
+          100,
+          new JdbcAccessSecurityConfig()
+          {
+            @Override
+            public Set<String> getAllowedProperties()
+            {
+              return ImmutableSet.of("valid_key1", "valid_key2");
+            }
+
+            @Override
+            public boolean isAllowUnknownJdbcUrlFormat()
+            {
+              return true;
+            }
+
+            @Override
+            public boolean isEnforceAllowedProperties()
+            {
+              return true;
+            }
+          }
+      );
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -217,6 +218,7 @@
         <module>extensions-core/protobuf-extensions</module>
         <module>extensions-core/lookups-cached-global</module>
         <module>extensions-core/lookups-cached-single</module>
+        <module>extensions-core/vectorized-lookups</module>
         <module>extensions-core/ec2-extensions</module>
         <module>extensions-core/s3-extensions</module>
         <module>extensions-core/druid-aws-rds-extensions</module>


### PR DESCRIPTION
## Executing queries
Vectorization only works for timeseries and groupBy queries. You also must enable it for that query using the context (You can do `vectorization: true` or `vectorization: force`, I preferred force because it would cause the query to fail if vectorization isn't used, though I did see some situations where that didn't happen). I also needed to `deferExpressionDimensions` to `singleString` in the context (this may have been because I was grouping by the looked up dimension, it may be unnecessary if that's not happening). I don't know if `deferExpressionDimensions` helps or hurts performance, but in my tests I didn't see any issues. 

For vectorization to work, you need to use the `vectorized_lookup` function instead of `lookup`. Also, the lookup name you pass needs to be a vectorizedLookup as well (a normal lookup will appear to work because vectorization for a normal lookup loops through the keys and does a query one by one). Lookups can a little bit of time when they're submitted to when they're actually available. There is a message in the historical logs once a lookup is available.

The query I was using to test in staging was:

``` sql
select
  t."embed_id" as "live_stream_event_id", 
  vectorized_lookup(concat(t."account_id", '_', t."visitor_key"), 'visitor_unique_id_lookup_mapdb')
from "form_events.v1.form_event.daily.v1" t
where account_id = 1
and t."embed_type" = 'LiveStreamEvent'
and t.embed_id in (110121, 0)
and TIME_IN_INTERVAL(t.__time, '2025-05-01/2025-07-31')
group by 1, 2
```

and this context:

``` json
{
  "vectorize": "force",
  "deferExpressionDimensions": "singleString"
}
```

This is the definition for the lookup that I used in staging:

``` json
{
  "type": "vectorizedLoadingLookup",
  "dataFetcher": {
    "type": "jdbcDataFetcher",
    "connectorConfig": {
      "connectURI": "jdbc:postgresql://bottler-staging16-bi-read-replica-encrypted.cfwh2p4tjre3.us-east-1.rds.amazonaws.com:5432/bottler",
      "user": "wistia",
      "password": {
        "type": "environment",
        "variable": "BOTTLER_DB_PASSWORD"
      },
      "dbcpProperties": {
        "initialSize": "2",
        "maxTotal": "10",
        "maxIdle": "5",
        "minIdle": "1"
      }
    },
    "table": "visitor_lookups_latest",
    "keyColumn": "account_visitor_key",
    "valueColumn": "unique_id"
  },
  "loadingCacheSpec": {
    "type": "mapDb",
    "maxStoreSize": 5
  },
  "reverseLoadingCacheSpec": {
    "type": "mapDb",
    "maxStoreSize": 5
  }
}
```

## Building Jar

I was using maven 3.9.9 setup via asdf.

```bash
mvn clean package -DskipTests -Dcheckstyle.skip=true -pl extensions-core/vectorized-lookups
cp ~/extensions-core/vectorized-lookups/target/druid-vectorized-lookups-33.0.0.jar ../grand-central/config/
cp ~/extensions-core/vectorized-lookups/target/druid-vectorized-lookups-33.0.0.jar ../analytics/docker/druid/prod/
```

## Building Docker Image

**Grand Central**

```bash
docker compose build druid
docker compose down druid
docker compose up druid
```

**Analytics**

There's a [github action](https://github.com/wistia/analytics/actions/workflows/druid-docker-build.yml) that builds 
the docker image and pushes it to ECR.

## Deploy Docker Image

You can get the image tag from the github action output. For example, `001688053317.dkr.ecr.us-east-1.amazonaws.com/analytics/druid:33.0.0-patch-e80cbaa92719a88694e8322b997a98e6882b9ffe`.

__Note: `33.0.0-patch-` is hard-coded into the build process__ 

Then you can update the image tag in https://github.com/wistia/gitops-shared-manifests/tree/main/druid in prod or staging. Flux will pick up the changes and deploy the new image. Also, make sure the extension is [enabled](https://github.com/wistia/gitops-shared-manifests/blob/main/druid/staging-5/druid.yaml#L74-L88).